### PR TITLE
preview html changes

### DIFF
--- a/ab_testing_tool_app/templates/edit_stage.html
+++ b/ab_testing_tool_app/templates/edit_stage.html
@@ -39,10 +39,10 @@
                     <td><input class="form-control"  type="text" name="name" value="{{ stage.name }}"/></td>
                 </tr>
                 {% for t, s in tracks %}
-                <tr align="left">
+                <tr align="left" class="url_box">
                     <td><label>URL for Track "{{t.name}}" </label></td>
-                    <td><input class="form-control"  type="text" id="url_{{t.id}}" name="stageurl_{{t.id}}" value="{{ s.url }}"/></td>
-                    <td><a id="preview_{{t.id}}" onclick="preview({{t.id}}); return False;" target="_blank" href="" class="btn btn-xs btn-success"/>Preview URL</a></td>
+                    <td><input id="url_{{t.id}}" class="form-control url_box_input"  type="url"  name="stageurl_{{t.id}}" value="{{ s.url }}"/></td>
+                    <td><a id="preview_{{t.id}}" target="_blank" href="" class="btn btn-xs btn-success preview-btn"/>Preview URL</a></td>
                 </tr>
                 {% endfor %}
                 <tr align="left">
@@ -59,13 +59,17 @@
            </form>
 </div>
 <script>
-function preview(t_id) {
-    url = document.getElementById('url_' + t_id).value;
+
+function set_preview_href() {
+    url = $(this).closest('.url_box').find(".url_box_input")[0].value; // fetches value from input
     if (url.substring(0, 7) != "http://" && url.substring(0, 8) != "https://") {
         url = "http://" + url;
     }
-    document.getElementById('preview_' + t_id).href = url;
+    this.href = url;
 }
+
+$(".preview-btn").click(set_preview_href);
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
Feature: preview Stage URLs in a new tab. 
Consists of: Small HTML/JS changes. 
Notes: 
- JS should be moved from HTML into separate file in static.
- There exists a check for "http://" because of undesired behavior where the lack thereof would result in Django directing a sample url "www.example.com" to "ab-testing-tool-server/www.example.com" instead of the desired "http://www.example.com"
