### PR TITLE
Feature/additional html modal

### DIFF
--- a/ab_testing_tool_app/templates/control_panel.html
+++ b/ab_testing_tool_app/templates/control_panel.html
@@ -37,11 +37,11 @@
                         <div class="modal-content">
                             <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                <h4 class="modal-title">Intervention Points Are Missing URLs</h4>
+                                <h4 class="modal-title">Some Intervention Points Are Missing URLs</h4>
                             </div>
                             <div class="modal-body">
-                                <p>Some Intervention Points are missing URLs</p>
-                                <p class="text-warning">These following Intervention Points are incomplete: {{ incomplete_stages|join:", " }} </p>
+                                <p>Complete your intervention points by filling in the URLs fields for all tracks.</p>
+                                <p class="text-warning">These following intervention points are incomplete: {{ incomplete_stages|join:", " }} </p>
                             </div>
                             <div class="modal-footer">
                                 <a class="btn btn-lg btn-primary" data-dismiss="modal"> Close </a>


### PR DESCRIPTION
HTML added. Goal: to show this modal to supercede finalize tracks modal if intervention points are missing urls.
Note: Dependency on feature/small_html_changes
