### PR TITLE
Feature/oauth retry

### DIFF
--- a/ab_tool/canvas.py
+++ b/ab_tool/canvas.py
@@ -53,8 +53,7 @@ def get_canvas_request_context(request):
 
 
 def handle_canvas_error(exception):
-    if (hasattr(exception, "response") and exception.response.status_code == 401
-        and exception.response.reason == "Unauthorized"):
+    if (hasattr(exception, "response") and exception.response.status_code == 401):
         raise NewTokenNeeded("Your canvas oauth token is invalid")
     logger.error(repr(exception))
     logger.error(traceback.format_exc())

--- a/ab_tool/tests/test_canvas.py
+++ b/ab_tool/tests/test_canvas.py
@@ -18,7 +18,6 @@ class TestCanvas(SessionTestCase):
         exception = RequestException()
         exception.response = MagicMock()
         exception.response.status_code = 401
-        exception.response.reason = "Unauthorized"
         return exception
     
     def test_get_lti_param_success(self):


### PR DESCRIPTION
Changes canvas SDK calls to raise NewTokenNeeded exception on unauthorized error which will prompt the oauth middleware to begin the token dance anew.

Updates tests.
