### PR TITLE
Feature/started experiment editing

### DIFF
--- a/ab_tool/templates/ab_tool/editExperiment.html
+++ b/ab_tool/templates/ab_tool/editExperiment.html
@@ -177,12 +177,6 @@
         window.modifiedExperiment = JSON.parse(JSON.stringify(window.initialExperiment));
         
         window.submitURL = "{% url 'ab_testing_tool_submit_create_experiment' %}";
-    
-    {% elif started %}
-        window.initialExperiment = JSON.parse("{{ experiment.to_json | escapejs}}");
-        window.modifiedExperiment = JSON.parse("{{ experiment.to_json | escapejs}}");
-        
-        window.submitURL = "{% url 'ab_testing_tool_submit_edit_started_experiment' experiment.id %}";
     {% else %}
         window.initialExperiment = JSON.parse("{{ experiment.to_json | escapejs}}");
         window.modifiedExperiment = JSON.parse("{{ experiment.to_json | escapejs}}");

--- a/ab_tool/urls.py
+++ b/ab_tool/urls.py
@@ -10,7 +10,7 @@ from ab_tool.views.intervention_point_pages import (submit_create_intervention_p
     submit_edit_intervention_point, modules_page_edit_intervention_point)
 from ab_tool.views.experiment_pages import (create_experiment, submit_create_experiment,
     edit_experiment, submit_edit_experiment, delete_experiment, finalize_tracks,
-    delete_track, submit_edit_started_experiment)
+    delete_track)
 
 urlpatterns = patterns('',
     url(r'^$', render_control_panel, name='ab_testing_tool_index'),
@@ -34,7 +34,6 @@ urlpatterns = patterns('',
     url(r'^submit_create_experiment$', submit_create_experiment, name='ab_testing_tool_submit_create_experiment'),
     url(r'^edit_experiment/(?P<experiment_id>\d+)$', edit_experiment, name='ab_testing_tool_edit_experiment'),
     url(r'^submit_edit_experiment/(?P<experiment_id>\d+)$', submit_edit_experiment, name='ab_testing_tool_submit_edit_experiment'),
-    url(r'^submit_edit_started_experiment/(?P<experiment_id>\d+)$', submit_edit_started_experiment, name='ab_testing_tool_submit_edit_started_experiment'),
     url(r'^delete_experiment/(?P<experiment_id>\d+)$', delete_experiment, name='ab_testing_tool_delete_experiment'),
     url(r'^delete_track/(?P<track_id>\d+)$', delete_track, name='ab_testing_tool_delete_track'),
     url(r'^finalize_tracks/(?P<experiment_id>\d+)$', finalize_tracks, name='ab_testing_tool_finalize_tracks'),


### PR DESCRIPTION
Updates the edit experiment form to have a third mode for started experiments. In this mode, you can view all the details of the experiment, but can only update the name and notes.

Also applies updates to experiment tests in line with these and earlier changes.

Remake of #90 against develop
