### PR TITLE
Bug Fix: InterventionPointInteraction storage and tests

### DIFF
--- a/ab_tool/analytics.py
+++ b/ab_tool/analytics.py
@@ -16,7 +16,7 @@ def log_intervention_point_interaction(course_id, student, intervention_point,
             intervention_point=intervention_point,
             experiment=experiment,
             track=track,
-            intervention_point_url=intervention_point_url
+            url=intervention_point_url.url
     )
 
 
@@ -56,7 +56,7 @@ def get_intervention_point_interactions_csv(experiment, file_title):
         for i in InterventionPointInteraction.objects.filter(experiment=experiment):
             row = [i.student.student_id, i.student.lis_person_sourcedid,
                    i.experiment.name, i.track.name,
-                   i.intervention_point.name, i.intervention_point_url.url, i.created_on]
+                   i.intervention_point.name, i.url, i.created_on]
             yield writer.writerow(row)
     response = StreamingHttpResponse(csv_file_generator(), content_type="text/csv")
     response['Content-Disposition'] = ("attachment; filename=%s" % file_title)

--- a/ab_tool/models.py
+++ b/ab_tool/models.py
@@ -189,4 +189,4 @@ class InterventionPointInteraction(CourseObject):
     intervention_point = models.ForeignKey(InterventionPoint)
     experiment = models.ForeignKey(Experiment, related_name="intervention_point_interactions")
     track = models.ForeignKey(Track)
-    intervention_point_url = models.ForeignKey(InterventionPointUrl)
+    url = models.URLField(max_length=2048)

--- a/ab_tool/tests/test_main_pages.py
+++ b/ab_tool/tests/test_main_pages.py
@@ -157,9 +157,11 @@ class TestMainPages(SessionTestCase):
                                          track=track, experiment=experiment)
         intervention_point = self.create_test_intervention_point(course_id=TEST_COURSE_ID)
         InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=student,
-                    intervention_point=intervention_point, experiment=experiment)
+                    intervention_point=intervention_point, experiment=experiment,
+                    track=track, url="http://example.com")
         InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=student,
-                    intervention_point=intervention_point, experiment=experiment)
+                    intervention_point=intervention_point, experiment=experiment,
+                    track=track, url="http://example.com")
         response = self.client.get(reverse("ab_testing_tool_download_intervention_point_interactions", args=(experiment.id,)))
         self.assertEqual(response._headers["content-type"],
                          ('Content-Type', 'text/csv'))
@@ -177,10 +179,12 @@ class TestMainPages(SessionTestCase):
                                          track=track, experiment=experiment2)
         intervention_point1 = self.create_test_intervention_point(course_id=TEST_COURSE_ID)
         InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=student1,
-                    intervention_point=intervention_point1, experiment=experiment1)
+                    intervention_point=intervention_point1, experiment=experiment1,
+                    track=track, url="http://example.com")
         intervention_point2 = self.create_test_intervention_point(course_id=TEST_OTHER_COURSE_ID)
         InterventionPointInteraction.objects.create(course_id=TEST_OTHER_COURSE_ID, student=student2,
-                    intervention_point=intervention_point2, experiment=experiment2)
+                    intervention_point=intervention_point2, experiment=experiment2,
+                    track=track, url="http://example.com")
         response = self.client.get(reverse("ab_testing_tool_download_intervention_point_interactions", args=(experiment1.id,)))
         self.assertEqual(response._headers["content-type"],
                          ('Content-Type', 'text/csv'))


### PR DESCRIPTION
- fixes broken tests surrounding intervention point interaction
- changes intervention point interaction to save actual url rather than database object reference
