### PR TITLE
 feature/edit_track_names

### DIFF
--- a/ab_tool/models.py
+++ b/ab_tool/models.py
@@ -75,7 +75,8 @@ class Experiment(CourseObject):
             "name": self.name,
             "notes": self.notes,
             "uniformRandom": bool(self.assignment_method == self.UNIFORM_RANDOM),
-            "tracks": [{"id": t.id, "weighting": t.get_weighting(), "name": t.name,
+            "tracks": [{"id": t.id, "weighting": t.get_weighting(),
+                        "name": t.name, "originalName" : t.name,
                         "deleteURL": reverse('ab_testing_tool_delete_track', args=(t.id,))}
                        for t in self.tracks.all()],
         }

--- a/ab_tool/static/ab_tool/css/bootstrap_customization.css
+++ b/ab_tool/static/ab_tool/css/bootstrap_customization.css
@@ -22,3 +22,25 @@ body.lti {
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
   display: none !important;
 }
+
+.editable {
+    color: #0000EE;
+    text-decoration: underline;
+    display: inline-block;
+    min-width: 10em;
+    min-height: 1em;
+    text-align: left;
+}
+
+.editable:hover {
+    color: #EE0000;
+}
+
+.editable:focus {
+    color: black;
+    text-decoration: none;
+    outline-color: blue;
+    outline-style: solid;
+    outline-width: 2px;
+    background-color: white !important;
+}

--- a/ab_tool/templates/ab_tool/editExperiment.html
+++ b/ab_tool/templates/ab_tool/editExperiment.html
@@ -53,7 +53,12 @@
                                         ng-cloak value="{{uniformPercent()}}">%
                                 </label>
                                 <label class="control-label">
-                                    <span data-track="name" title="Edit track name" ng-cloak>Track "{{track.name}}"</span>
+                                    <!-- TODO: disable undo function from changing data inside unselected contenteditable spans -->
+                                    Track&nbsp<span data-track="name" title="Edit track name"
+                                        ng-cloak ng-model="track.newName"
+                                        ng-change="trackNameChanged(track)"
+                                        class="editable"
+                                        contenteditable="true"></span>
                                 </label>
                             </li>
                         <!-- End Angular loop over tracks -->
@@ -162,7 +167,8 @@
     <script type="text/javascript">
     
     window.initialExperiment = {"name": "", "notes": "", "uniformRandom": true,
-        "tracks": [{"id": null, "name": "A"}, {"id": null, "name": "B"}]};
+        "tracks": [{"id": null, "name": "A", "newName": "A"},
+                   {"id": null, "name": "B", "newName": "B"}]};
     window.modifiedExperiment = JSON.parse(JSON.stringify(window.initialExperiment));
     
     window.submitURL = "{% url 'ab_testing_tool_submit_create_experiment' %}";


### PR DESCRIPTION
Implements contenteditable and integration with angular to allow editing track names in the create/edit experiment form.

Track names appear as links, then become text boxes on selection; deselction, [enter] and [esc] cause changes to be updated in Javascript models.

known bug: hitting the browser undo function with no UI element selected causes the interface and angular model to become out of sync; this just causes a confusing display for the users and does not cause any actually incorrect behavior.
