### PR TITLE
Convert secure.py.j2 file to use lowercase keys to be consistent with ot...

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ when installing lxml, refer to this: http://stackoverflow.com/a/22322645/2812260
 * Edit the new ab_testing_tool/settings/secure.py and fill in values requested there.
   The minimum needed for local setup is as follows:
   Add a line to the dictionary containing the access token from Canvas styled like this:
-  `"COURSE_OAUTH_TOKEN": "asdlkjf234aADKUEJskjdf2l3a6k7sjdf",`.
-  Replace `{{ secure_settings.admins_tuple }}` with `None`.
+  `"course_oauth_token": "asdlkjf234aADKUEJskjdf2l3a6k7sjdf",`.
   Replace `'{{ secure_settings.lti_key }}': '{{ secure_settings.lti_secret }}'`
   with `"test": "secret"`.
 

--- a/ab_testing_tool/settings/base.py
+++ b/ab_testing_tool/settings/base.py
@@ -48,16 +48,16 @@ path.append(SITE_ROOT)
 
 ### End path stuff
 
-CLIENT_ID = SECURE_SETTINGS.get("CLIENT_ID")
-CLIENT_SECRET = SECURE_SETTINGS.get("CLIENT_SECRET")
+CLIENT_ID = SECURE_SETTINGS.get('client_id')
+CLIENT_SECRET = SECURE_SETTINGS.get('client_secret')
 
 # THESE ADDRESSES WILL RECEIVE EMAIL ABOUT CERTAIN ERRORS!
-ADMINS = SECURE_SETTINGS.get("ADMINS")
+ADMINS = ()
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = SECURE_SETTINGS.get('DJANGO_SECRET_KEY', 'changeme')
+SECRET_KEY = SECURE_SETTINGS.get('django_secret_key', 'changeme')
 
-LTI_OAUTH_CREDENTIALS = SECURE_SETTINGS.get('LTI_OAUTH_CREDENTIALS', None)
+LTI_OAUTH_CREDENTIALS = SECURE_SETTINGS.get('lti_oauth_credentials', None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/ab_testing_tool/settings/secure.py.j2
+++ b/ab_testing_tool/settings/secure.py.j2
@@ -1,17 +1,11 @@
 SECURE_SETTINGS = {
-    'LTI_OAUTH_CREDENTIALS': {
+    'lti_oauth_credentials': {
         '{{ secure_settings.lti_key }}': '{{ secure_settings.lti_secret }}',
     },
-    
-    'CLIENT_ID': '{{ secure_settings.client_id }}',
-    'CLIENT_SECRET': '{{ secure_settings.client_secret }}',
-    
-    'ADMINS': (),
-    
-    'DJANGO_DB_USER': '{{ secure_settings.django_db_user }}',
-    'DJANGO_DB_PASS': '{{ secure_settings.django_db_pass }}',
-    
-    'CANVAS_TOKEN': '{{ secure_settings.canvas_token }}',
-    
-    'DJANGO_SECRET_KEY': '{{ secure_settings.django_secret_key }}',
+    'client_id': '{{ secure_settings.client_id }}',
+    'client_secret': '{{ secure_settings.client_secret }}',
+    'django_db_user': '{{ secure_settings.django_db_user }}',
+    'django_db_pass': '{{ secure_settings.django_db_pass }}',
+    'canvas_token': '{{ secure_settings.canvas_token }}',
+    'django_secret_key': '{{ secure_settings.django_secret_key }}',
 }

--- a/ab_tool/canvas.py
+++ b/ab_tool/canvas.py
@@ -118,8 +118,8 @@ def get_lti_param(request, key):
 
 def get_canvas_request_context(request):
     # FOR LOCAL DEVLEOPEMENT PURPOSES. TODO: Remove if-block in production.
-    if "COURSE_OAUTH_TOKEN" in settings.SECURE_SETTINGS:
-        oauth_token = settings.SECURE_SETTINGS["COURSE_OAUTH_TOKEN"]
+    if "course_oauth_token" in settings.SECURE_SETTINGS:
+        oauth_token = settings.SECURE_SETTINGS["course_oauth_token"]
     else:
         oauth_token = get_token(request)
     canvas_domain = get_lti_param(request, "custom_canvas_api_domain")


### PR DESCRIPTION
...her projects.  Make local development secure setting reference also use lowercase key.  Update README instructions related to secure keys.  Since ADMINS tuple is empty, move it out of secure settings and into base.