### PR TITLE
Add psycopg2 requirement for using postgres as a database backend (mainl...

### DIFF
--- a/ab_testing_tool/requirements/base.txt
+++ b/ab_testing_tool/requirements/base.txt
@@ -12,3 +12,4 @@ django-redis-cache==0.10.2
 hiredis==0.1.2
 django-redis-sessions==0.4.0
 gunicorn
+psycopg2

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -50,6 +50,11 @@ package {'libaio-dev':
     require => Exec['apt-get-update']
 }
 
+package {'libpq-dev':
+    ensure => installed,
+    require => Exec['apt-get-update']
+}
+
 package {'git':
     ensure => latest,
     require => Exec['apt-get-update'],


### PR DESCRIPTION
...y for non-development environments).  Update Vagrant file to include python library that is necessary to be present in an Ubuntu environment for the psycopg2 req to be compiled.