### PR TITLE
Feature/dashboard_js

### DIFF
--- a/ab_tool/static/ab_tool/js/edit_experiment.js
+++ b/ab_tool/static/ab_tool/js/edit_experiment.js
@@ -149,7 +149,7 @@ var controller = function($scope, $window, $http) {
         /**
          * Removes the track from the list of tracks on the experiment,
          * causing it to be removed from the interface.
-         * 
+         *
          * Note: this function checks for a matching track by identity;
          * consequently you must pass the track itself, not just a copy of it
          * or an object with the same attributes. (i.e. you must pass by reference)

--- a/ab_tool/static/ab_tool/js/experiments_dashboard.js
+++ b/ab_tool/static/ab_tool/js/experiments_dashboard.js
@@ -1,0 +1,94 @@
+$(document).ready(function(){
+
+    //double click-submission protection
+    $(".submitter").click(function (event) {
+        if ($(this).hasClass("disabled")) {
+            event.preventDefault();
+        }
+        $(this).addClass("disabled");
+    });
+
+
+    function is_valid_url(url) {
+        return /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(url);
+    }
+
+    $('.addIntervention').modal('show');
+
+    $('select').selectmenu({
+        format: function(text){
+            var pattern = /([\s\S]+)\-\- ([\s\S]+)/;
+            var replacement = '<span class="option-title">$1</span><span class="option-description">$2</span>';
+            return text.replace(pattern, replacement);
+        }
+    });
+    
+    //for showing preview buttons when creating or editgin and intervention point
+    $('[data-modal="intervention-edit"], [data-modal="intervention-new"]').on('show.bs.modal', function (e) {
+
+        //go through each track url to show/hide preview link
+        $('.intervention-url').each(function(i){
+            //on modal show we validate and show the preview
+            if ( is_valid_url( $(this).val().trim() ) ){
+                $(this)
+                    .siblings('.preview-link')
+                    .attr({
+                        href:$(this).val().trim(),
+                        target: '_blank'
+                    });
+            }else{
+                $(this).siblings('.preview-link').hide();
+            }
+            
+            //as they change the input url field
+            $(this).on('input', function(){
+                if ( is_valid_url( $(this).val().trim() ) ){
+                    
+                    if ( $(this).siblings('.preview-link').is(":hidden") ){
+                        $(this).siblings('.preview-link').show();
+                    }
+
+                    $(this)
+                        .siblings('.preview-link')
+                        .attr({
+                            href:$(this).val().trim(),
+                            target: '_blank'
+                        });
+                }else{
+                    $(this).siblings('.preview-link').hide();
+                }
+                
+            });
+
+        });//end each
+
+        //e.currentTarget = references the modal window that's open
+        var $currentModal = $(e.currentTarget);
+        //find the intervention name for the window that's open
+        var $interventionName = $currentModal.find('.intervention-name');
+
+        //disable the create button if IP name is empty
+        //this is mostly for new IP
+        if ( !$.trim( $interventionName.val() ).length ){
+            $currentModal.find('button').addClass('disabled');
+        }
+        
+        //update error class and able/disabled button as the user
+        //changes the intervention name input
+        $interventionName.on('input', function(){
+            if ( $.trim( $(this).val() ).length ){
+                $currentModal.find('button').removeClass('disabled');
+                if ( $(this).hasClass('has-error') ){
+                    $(this).removeClass('has-error');
+                }
+            }else{
+                $currentModal.find('button').addClass('disabled');
+                $(this).addClass('has-error');
+            }
+        });
+
+    });
+    
+
+    $('[data-toggle="tooltip"]').tooltip();
+});

--- a/ab_tool/templates/ab_tool/experiments_dashboard.html
+++ b/ab_tool/templates/ab_tool/experiments_dashboard.html
@@ -8,7 +8,6 @@
 
 {% block content %}
 
-
 <header>
     <div>
         <h1>A/B Testing Dashboard</h1>
@@ -105,10 +104,10 @@
                             {% for intervention_point in experiment.intervention_points.all %}
                                 <li>
                                     {% if intervention_point in uninstalled_intervention_points %}
-                                        <a href="{% url 'ab_testing_tool_delete_intervention_point' intervention_point.id %}" 
-                                            data-toggle="tooltip" data-placement="top" 
+                                        <a href="{% url 'ab_testing_tool_delete_intervention_point' intervention_point.id %}"
+                                            data-toggle="tooltip" data-placement="top"
                                             title="Delete Intervention Point '{{intervention_point.name}}'"
-                                            class="btn btn-icon-only ip-btn-delete">
+                                            class="btn btn-icon-only ip-btn-delete submitter">
                                             <i class="fa fa-trash"></i><span>Delete</span>
                                         </a>
                                     {% else %}
@@ -125,7 +124,7 @@
                                         <span>URLs missing</span>
                                     </span>
                                     {% endif %}
-                                    {% if intervention_point not in uninstalled_intervention_points %} 
+                                    {% if intervention_point not in uninstalled_intervention_points %}
                                     <span class="ip-status ip-installed">
                                         <i class="fa fa-check"></i>
                                         <span>Installed</span>
@@ -157,12 +156,16 @@
                             </li>
                             {% if experiment.tracks_finalized %}
                                 <li>
-                                    <a id="download_students_button" href="{% url 'ab_testing_tool_download_data' experiment.id %}" class="btn btn-icon btn-ip-options">
+                                    <a id="download_students_button"
+                                       href="{% url 'ab_testing_tool_download_data' experiment.id %}"
+                                       class="btn btn-icon btn-ip-options submitter">
                                         <i class="fa fa-download"></i>Download Students
                                     </a>
                                 </li>
                                 <li>
-                                    <a id="download_intervention_point_interactions_button" href="{% url 'ab_testing_tool_download_intervention_point_interactions' experiment.id %}" class="btn btn-icon btn-ip-options">
+                                    <a id="download_intervention_point_interactions_button"
+                                       href="{% url 'ab_testing_tool_download_intervention_point_interactions' experiment.id %}"
+                                       class="btn btn-icon btn-ip-options submitter">
                                         <i class="fa fa-download"></i>Download Interactions
                                     </a>
                                 </li>
@@ -190,6 +193,7 @@
             </div>
         {% endfor %}
     </div>
+</div>
 </main>
 
 
@@ -197,94 +201,10 @@
 
 {% endblock %}
 
+
 {% block javascript %}
 {{ block.super }}
 <script src="{% static 'ab_tool/js/jquery.dropdown.js' %}" type="text/javascript"></script>
+<script src="{% static 'ab_tool/js/experiments_dashboard.js' %}"></script>
 
-<script type="text/javascript">
-$(document).ready(function(){
-    function is_valid_url(url) {
-        return /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(url);
-    }
-
-    $('.addIntervention').modal('show');
-
-    $('select').selectmenu({
-        format: function(text){
-            var pattern = /([\s\S]+)\-\- ([\s\S]+)/;
-            var replacement = '<span class="option-title">$1</span><span class="option-description">$2</span>';
-            return text.replace(pattern, replacement);
-        }
-    });
-    
-    //for showing preview buttons when creating or editgin and intervention point
-    $('[data-modal="intervention-edit"], [data-modal="intervention-new"]').on('show.bs.modal', function (e) {
-
-        //go through each track url to show/hide preview link
-        $('.intervention-url').each(function(i){
-            //on modal show we validate and show the preview
-            if ( is_valid_url( $(this).val().trim() ) ){
-                $(this)
-                    .siblings('.preview-link')
-                    .attr({
-                        href:$(this).val().trim(), 
-                        target: '_blank'
-                    });
-            }else{
-                $(this).siblings('.preview-link').hide();
-            }
-            
-            //as they change the input url field
-            $(this).on('input', function(){
-                if ( is_valid_url( $(this).val().trim() ) ){
-                    
-                    if ( $(this).siblings('.preview-link').is(":hidden") ){
-                        $(this).siblings('.preview-link').show();
-                    }
-
-                    $(this)
-                        .siblings('.preview-link')
-                        .attr({
-                            href:$(this).val().trim(), 
-                            target: '_blank'
-                        });
-                }else{
-                    $(this).siblings('.preview-link').hide();
-                }
-                
-            });
-
-        });//end each
-
-        //e.currentTarget = references the modal window that's open 
-        var $currentModal = $(e.currentTarget);
-        //find the intervention name for the window that's open
-        var $interventionName = $currentModal.find('.intervention-name');
-
-        //disable the create button if IP name is empty
-        //this is mostly for new IP
-        if ( !$.trim( $interventionName.val() ).length ){
-            $currentModal.find('button').addClass('disabled');
-        }
-        
-        //update error class and able/disabled button as the user
-        //changes the intervention name input
-        $interventionName.on('input', function(){
-            if ( $.trim( $(this).val() ).length ){
-                $currentModal.find('button').removeClass('disabled');
-                if ( $(this).hasClass('has-error') ){
-                    $(this).removeClass('has-error');
-                }
-            }else{
-                $currentModal.find('button').addClass('disabled');
-                $(this).addClass('has-error');
-            }  
-        });
-
-    });
-    
-
-    $('[data-toggle="tooltip"]').tooltip();
-});
-</script>
 {% endblock %}

--- a/ab_tool/templates/ab_tool/modals.html
+++ b/ab_tool/templates/ab_tool/modals.html
@@ -59,7 +59,7 @@
                     <legend class="sr-only">Name of intervention point</legend>
                     <div class="form-group">
                         <label for="interventionName">Name:</label> <i class="fa fa-asterisk"></i>
-                        <input type="text" name="name" id="interventionName" class="form-control intervention-name" 
+                        <input type="text" name="name" id="interventionName" class="form-control intervention-name"
                                 placeholder="Enter Intervention Name">
                     </div>
                     <div class="form-group-description">
@@ -113,7 +113,7 @@
             <div class="modal-footer">
                 <a href="#" class="btn btn-link" data-dismiss="modal">Cancel</a>
                 <!--input type="submit" class="btn btn-submit-primary" value="Save"-->
-                <button type="submit" class="btn btn-submit-primary intervention-create">Create</button>
+                <button type="submit" class="btn btn-submit-primary intervention-create submitter">Create</button>
             </div>
         </form>
     </div>
@@ -142,7 +142,7 @@
                     <div class="form-group">
                         <label for="intervention_{{intervention_point.id}}">Name:</label>
                         <input type="text" name="name" id="intervention_{{intervention_point.id}}"
-                            class="form-control intervention-name" value="{{intervention_point.name}}" 
+                            class="form-control intervention-name" value="{{intervention_point.name}}"
                             placeholder="Enter Intervention Name">
                         <!--a href="#"><i class="fa fa-question-circle"></i></a-->
                     </div>
@@ -208,7 +208,7 @@
             </div>
             <div class="modal-footer">
                 <a href="#" class="btn btn-link" data-dismiss="modal">Cancel</a>
-                <button type="submit" class="btn btn-submit-primary intervention-update">Update</button>
+                <button type="submit" class="btn btn-submit-primary intervention-update submitter">Update</button>
             </div>
         </form>
     </div>
@@ -255,7 +255,7 @@
             </div>
             <div class="modal-footer">
                 <a class="btn btn-lg btn-submit-primary" data-dismiss="modal"> Close </a>
-                <a class="btn btn-lg btn-submit" href="{% url 'ab_testing_tool_finalize_tracks' experiment.id %}"> Yes, Start Experiment </a>
+                <a class="btn btn-lg btn-submit submitter" href="{% url 'ab_testing_tool_finalize_tracks' experiment.id %}"> Yes, Start Experiment </a>
             </div>
         </div>
     </div>
@@ -279,7 +279,7 @@
             </div>
             <div class="modal-footer">
                 <a class="btn btn-lg btn-submit-primary" data-dismiss="modal"> Close </a>
-                <a class="btn btn-lg btn-link"  href="{% url 'ab_testing_tool_delete_experiment' experiment.id %}"> Yes, Delete Experiment </a>
+                <a class="btn btn-lg btn-link submitter"  href="{% url 'ab_testing_tool_delete_experiment' experiment.id %}"> Yes, Delete Experiment </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
@roderickmorales 
Adds simple JQuery class-based double click/submission protection. Class `submitter` is added to actionable links:
- deleting intervention point
- coping/cloning an experiment
- downloading data
- updating intervention point
- creating intervention point
- deleting am experiment

