### PR TITLE
Feature/oauth renderable error page

### DIFF
--- a/ab_testing_tool/settings/base.py
+++ b/ab_testing_tool/settings/base.py
@@ -146,6 +146,11 @@ TEMPLATE_DIRS = (
     os.path.join(BASE_DIR, 'templates'),
 )
 
+# renderable_error.html is the default template specified in error_middleware and can be changed if desired
+RENDERABLE_ERROR_TEMPLATE = "renderable_error.html"
+# oauth_error.html is the default template specified in django_canvas_oauth and can be changed if desired
+OAUTH_ERROR_TEMPLATE = "oauth_error.html"
+
 CANVAS_OAUTH_CLIENT_ID = ENV_SETTINGS.get('client_id')
 CANVAS_OAUTH_CLIENT_SECRET = ENV_SETTINGS.get('client_secret')
 

--- a/ab_testing_tool/templates/oauth_error.html
+++ b/ab_testing_tool/templates/oauth_error.html
@@ -2,14 +2,9 @@
 {% load static %}
 
 {% block content %}
-
-<header>
-    <div>
-        <h1>A/B Testing Dashboard</h1>
-    </div>
-</header>
 <main>
 
-<h2>Error: {{ message }}</h2>
+<h2>OAuth Error: {{ message }}</h2>
 
+</main>
 {% endblock %}

--- a/ab_testing_tool/templates/oauth_error.html
+++ b/ab_testing_tool/templates/oauth_error.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% load staticfiles %}
+    <meta charset="utf-8" />
+    <title>A/B Testing Tool</title>
+    <link rel="stylesheet" href="{% static 'ab_tool/css/bootstrap.min.css' %}" type="text/css"/>
+</head>
+<body>
+    <h2>OAuth Error: {{ message }}</h2>
+</body>
+</html>

--- a/ab_testing_tool/templates/oauth_error.html
+++ b/ab_testing_tool/templates/oauth_error.html
@@ -4,7 +4,7 @@
 {% block content %}
 <main>
 
-<h2>OAuth Error: {{ message }}</h2>
+<h2>Uh-oh, we couldn't obtain permission. OAuth Error: {{ message }}</h2>
 
 </main>
 {% endblock %}

--- a/ab_testing_tool/templates/oauth_error.html
+++ b/ab_testing_tool/templates/oauth_error.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    {% load staticfiles %}
-    <meta charset="utf-8" />
-    <title>A/B Testing Tool</title>
-    <link rel="stylesheet" href="{% static 'ab_tool/css/bootstrap.min.css' %}" type="text/css"/>
-</head>
-<body>
-    <h2>OAuth Error: {{ message }}</h2>
-</body>
-</html>
+{% extends "ab_tool/base_lti.html" %}
+{% load static %}
+
+{% block content %}
+
+<header>
+    <div>
+        <h1>A/B Testing Dashboard</h1>
+    </div>
+</header>
+<main>
+
+<h2>Error: {{ message }}</h2>
+
+{% endblock %}

--- a/ab_testing_tool/templates/renderable_error.html
+++ b/ab_testing_tool/templates/renderable_error.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    {% load staticfiles %}
-    <meta charset="utf-8" />
-    <title>A/B Testing Tool</title>
-    <link rel="stylesheet" href="{% static 'ab_tool/css/bootstrap.min.css' %}" type="text/css"/>
-</head>
-<body>
-    <h2>Error: {{ message }}</h2>
-</body>
-</html>
+{% extends "ab_tool/base_lti.html" %}
+{% load static %}
+
+{% block content %}
+
+<header>
+    <div>
+        <h1>A/B Testing Dashboard</h1>
+    </div>
+</header>
+<main>
+
+<h2>Error: {{ message }}</h2>
+
+{% endblock %}

--- a/ab_testing_tool/templates/renderable_error.html
+++ b/ab_testing_tool/templates/renderable_error.html
@@ -4,7 +4,7 @@
 {% block content %}
 <main>
 
-<h2>Error: {{ message }}</h2>
+<h2>Sorry, but something went wrong. Error: {{ message }}</h2>
 
 </main>
 {% endblock %}

--- a/ab_testing_tool/templates/renderable_error.html
+++ b/ab_testing_tool/templates/renderable_error.html
@@ -2,14 +2,9 @@
 {% load static %}
 
 {% block content %}
-
-<header>
-    <div>
-        <h1>A/B Testing Dashboard</h1>
-    </div>
-</header>
 <main>
 
 <h2>Error: {{ message }}</h2>
 
+</main>
 {% endblock %}

--- a/django_canvas_oauth/exceptions.py
+++ b/django_canvas_oauth/exceptions.py
@@ -2,6 +2,7 @@ class CanvasOauthError(Exception): pass
 
 class NewTokenNeeded(CanvasOauthError): pass
 
+#Unused
 class BadOAuthReturnError(CanvasOauthError): pass
 
 class BadLTIConfigError(CanvasOauthError): pass

--- a/django_canvas_oauth/oauth.py
+++ b/django_canvas_oauth/oauth.py
@@ -5,8 +5,7 @@ from django.shortcuts import redirect
 from rauth import OAuth2Service
 
 from django_canvas_oauth.models import OAuthToken
-from django_canvas_oauth.exceptions import (NewTokenNeeded, BadLTIConfigError,
-    BadOAuthReturnError)
+from django_canvas_oauth.exceptions import (NewTokenNeeded, BadLTIConfigError)
 from django.template.base import TemplateDoesNotExist
 from django.template import loader
 from django.http.response import HttpResponse

--- a/django_canvas_oauth/tests.py
+++ b/django_canvas_oauth/tests.py
@@ -76,14 +76,6 @@ class TestMiddleware(TestCase):
         redirect_url = response._headers['location'][1]
         self.assertIn(AUTHORIZE_URL_PATTERN % self.TEST_DOMAIN, redirect_url)
     
-#     def test_oauth_callback_bad_params(self):
-#         """ Tests that oauth_callback errors on an error param or no params """
-#         self.assertRaises(BadOAuthReturnError, oauth_callback, self.request())
-#         self.assertRaises(BadOAuthReturnError, oauth_callback,
-#                            self.request(get_params={"error": "some_error"}))
-#         self.assertRaises(BadOAuthReturnError, oauth_callback,
-#                            self.request(get_params={"error": "x", "code": "y"}))
-    
     @patch("error_middleware.middleware.loader.render_to_string")
     def test_oauth_callback_fails_with_template(self, mock_renderer):
         response = oauth_callback(self.request())
@@ -96,7 +88,7 @@ class TestMiddleware(TestCase):
         mock_renderer.assert_called_with(OAUTH_ERROR_TEMPLATE, {"message":
                                 "test_error"})
         self.assertEqual(response.status_code, 403)
-
+    
     @patch("error_middleware.middleware.loader.render_to_string",
            side_effect=TemplateDoesNotExist)
     def test_oauth_callback_fails_without_error_template(self, mock_renderer):


### PR DESCRIPTION
This changes django_canvas_oauth such that when an oauth error occurs (such as when permission is not granted), an error template that can be styled (e.g. oauth_error.html) is rendered instead of an exception being raised. Corresponding tests for this feature and included in this pull request.

@roderickmorales , you are welcome to want to style these error templates as determined by @mmtchong 

This pull request also includes:
- Cleans up imports; fixes spelling typo; new comments; 