### PR TITLE
Fix/copy experiment naming

### DIFF
--- a/ab_tool/exceptions.py
+++ b/ab_tool/exceptions.py
@@ -44,6 +44,7 @@ INVALID_URL_PARAM = Renderable400("One of your URL inputs is invalid.")
 
 PARAM_LENGTH_EXCEEDS_LIMIT = Renderable400("There are length limitations. At least one of your inputs is too long.")
 
+COPIES_EXCEEDS_LIMIT = Renderable400("There exists too many copies of the experiment you are trying to copy. Please delete some before copying.")
 
 def DATABASE_ERROR(error_message):
     return Renderable400("%s" % error_message)

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -148,7 +148,7 @@ def submit_edit_experiment(request, experiment_id):
 @lti_role_required(ADMINS)
 def copy_experiment(request, experiment_id):
     course_id = get_lti_param(request, "custom_canvas_course_id")
-    experiment = Experiment.get_or_404_check_course(experiment_id, course_id).na
+    experiment = Experiment.get_or_404_check_course(experiment_id, course_id)
     experiments_with_prefix = set([e.name for e in Experiment.objects.filter(
             course_id=course_id, name__startswith=experiment.name)])
     for i in range(1,1000):

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -154,11 +154,9 @@ def copy_experiment(request, experiment_id):
     for i in range(1,1000):
         new_name = "%s_copy%s" % (experiment.name, i)
         if new_name not in experiments_with_prefix:
-            break
-    else:
-        raise COPIES_EXCEEDS_LIMIT
-    experiment.copy(new_name)
-    return redirect(reverse("ab_testing_tool_index"))
+            experiment.copy(new_name)
+            return redirect(reverse("ab_testing_tool_index"))
+    raise COPIES_EXCEEDS_LIMIT
 
 
 @lti_role_required(ADMINS)


### PR DESCRIPTION
Changes implementation of copy_experiment such that choosing the new name avoids hitting the database's unique-name constraint, which previously occurred when copied experiments were deleted.