### PR TITLE
Feature/Prevent OAuth Loop

### DIFF
--- a/ab_testing_tool/templates/oauth_error.html
+++ b/ab_testing_tool/templates/oauth_error.html
@@ -4,7 +4,8 @@
 {% block content %}
 <main>
 
-<h2>Uh-oh, we couldn't obtain permission. OAuth Error: {{ message }}</h2>
+<h2>Uh-oh, we couldn't obtain permission.</h2>
+<p>OAuth Error: {{ message }}</p>
 
 </main>
 {% endblock %}

--- a/django_canvas_oauth/oauth.py
+++ b/django_canvas_oauth/oauth.py
@@ -1,14 +1,16 @@
 import json
+from datetime import timedelta
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.http.response import HttpResponse
 from django.shortcuts import redirect
+from django.template.base import TemplateDoesNotExist
+from django.template import loader
+from django.utils import timezone
 from rauth import OAuth2Service
 
 from django_canvas_oauth.models import OAuthToken
 from django_canvas_oauth.exceptions import (NewTokenNeeded, BadLTIConfigError)
-from django.template.base import TemplateDoesNotExist
-from django.template import loader
-from django.http.response import HttpResponse
 
 
 BASE_URL_PATTERN = "https://%s/"
@@ -41,6 +43,26 @@ def begin_oauth(request):
         user came from so they can be redirected back there at the end.
         https://canvas.instructure.com/doc/api/file.oauth.html """
     request.session["oauth_return_uri"] = request.get_full_path()
+    try:
+        # If we detect that the user generated an OAuth token in the past 30
+        # seconds, the user is almost certainly caught in the OAuth login loop.
+        # This is most likely caused by the fact that the python_canvas_sdk
+        # returns multiple kinds of 401 errors, including
+        # 401: {u'errors': [{u'message': u'Invalid access token.'}]
+        # for which we want to generate a new token, but also
+        # 401: {u'status': u'unauthorized', u'errors':
+        #       [{u'message': u'user not authorized to perform that action'}]}
+        # for which the user deosn't have sufficient permission to use the
+        # A/B testing tool for the course.
+        token_updated = request.user.oauthtoken.updated_on
+        if timezone.now() - token_updated < timedelta(seconds=30):
+            return render_oauth_error(
+                    "It appears you don't have sufficient canvas permissions " +
+                    "to use the A/B Testing Tool for this course.  " +
+                    "Please contact your canvas administrator."
+            )
+    except OAuthToken.DoesNotExist:
+        pass
     service = get_oauth_service(request)
     redirect_uri = request.build_absolute_uri(reverse("django_canvas_oauth:oauth_page"))
     #TODO: Implement with param `state` for security. See cited documentation.

--- a/django_canvas_oauth/oauth.py
+++ b/django_canvas_oauth/oauth.py
@@ -52,13 +52,12 @@ def begin_oauth(request):
         # for which we want to generate a new token, but also
         # 401: {u'status': u'unauthorized', u'errors':
         #       [{u'message': u'user not authorized to perform that action'}]}
-        # for which the user deosn't have sufficient permission to use the
-        # A/B testing tool for the course.
+        # which means the user deosn't have sufficient permissions in the course.
         token_updated = request.user.oauthtoken.updated_on
         if timezone.now() - token_updated < timedelta(seconds=30):
             return render_oauth_error(
                     "It appears you don't have sufficient canvas permissions " +
-                    "to use the A/B Testing Tool for this course.  " +
+                    "to use this external tool for this course.  " +
                     "Please contact your canvas administrator."
             )
     except OAuthToken.DoesNotExist:

--- a/django_canvas_oauth/oauth.py
+++ b/django_canvas_oauth/oauth.py
@@ -43,30 +43,38 @@ def begin_oauth(request):
         user came from so they can be redirected back there at the end.
         https://canvas.instructure.com/doc/api/file.oauth.html """
     request.session["oauth_return_uri"] = request.get_full_path()
-    try:
-        # If we detect that the user generated an OAuth token in the past 30
-        # seconds, the user is almost certainly caught in the OAuth login loop.
-        # This is most likely caused by the fact that the python_canvas_sdk
-        # returns multiple kinds of 401 errors, including
-        # 401: {u'errors': [{u'message': u'Invalid access token.'}]
-        # for which we want to generate a new token, but also
-        # 401: {u'status': u'unauthorized', u'errors':
-        #       [{u'message': u'user not authorized to perform that action'}]}
-        # which means the user deosn't have sufficient permissions in the course.
-        token_updated = request.user.oauthtoken.updated_on
-        if timezone.now() - token_updated < timedelta(seconds=30):
-            return render_oauth_error(
-                    "It appears you don't have sufficient canvas permissions " +
-                    "to use this external tool for this course.  " +
-                    "Please contact your canvas administrator."
-            )
-    except OAuthToken.DoesNotExist:
-        pass
+    if check_for_redirect_loop(request):
+        return render_oauth_error(
+            "It appears you don't have sufficient canvas permissions to use this " +
+            "external tool for this course.  Please contact your canvas administrator."
+        )
     service = get_oauth_service(request)
     redirect_uri = request.build_absolute_uri(reverse("django_canvas_oauth:oauth_page"))
     #TODO: Implement with param `state` for security. See cited documentation.
     return redirect(service.get_authorize_url(response_type="code",
                                               redirect_uri=redirect_uri))
+
+
+def check_for_redirect_loop(request):
+    """
+    If we detect that the user generated an OAuth token in the past 30
+    seconds, the user is almost certainly caught in the OAuth login loop.
+    This is most likely caused by the fact that the python_canvas_sdk
+    returns multiple kinds of 401 errors, including
+    401: {u'errors': [{u'message': u'Invalid access token.'}]
+    for which we want to generate a new token, but also
+    401: {u'status': u'unauthorized', u'errors':
+          [{u'message': u'user not authorized to perform that action'}]}
+    which means the user deosn't have sufficient permissions in the course.
+    """
+    try:
+        token_updated = request.user.oauthtoken.updated_on
+        if timezone.now() - token_updated < timedelta(seconds=30):
+            return True
+    except OAuthToken.DoesNotExist:
+        pass
+    return False
+
 
 
 def oauth_callback(request):


### PR DESCRIPTION
Adds logic to django_canvas_oauth to raise an error if the user is caught in an oauth redirect loop (this bug was replicated for a user in canvas that doesn't have sufficient permission to perform one of the SDK calls, and due to that causing a 401 error the same as the invalid token error, causes the oauth library to be stuck in the loop of trying to generate a valid token for the user)