### PR TITLE
Feature/tlt 923 fix intervention validations

### DIFF
--- a/ab_tool/static/ab_tool/js/experiments_dashboard.js
+++ b/ab_tool/static/ab_tool/js/experiments_dashboard.js
@@ -9,7 +9,7 @@ $(document).ready(function(){
     });
 
     function is_valid_url(url) {
-        return /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(url);
+        return /^(http(s)?:\/\/)?(www\.)?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(url);
     }
 
     $('.addIntervention').modal('show');

--- a/ab_tool/static/ab_tool/js/experiments_dashboard.js
+++ b/ab_tool/static/ab_tool/js/experiments_dashboard.js
@@ -9,7 +9,7 @@ $(document).ready(function(){
     });
 
     function is_valid_url(url) {
-        return /^(http(s)?:\/\/)?(www\.)?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(url);
+        return /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i.test(url);
     }
 
     $('.addIntervention').modal('show');

--- a/ab_tool/static/ab_tool/js/experiments_dashboard.js
+++ b/ab_tool/static/ab_tool/js/experiments_dashboard.js
@@ -9,7 +9,7 @@ $(document).ready(function(){
     });
 
     function is_valid_url(url) {
-        return /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i.test(url);
+        return /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i.test(url);
     }
 
     $('.addIntervention').modal('show');

--- a/ab_tool/views/intervention_point_pages.py
+++ b/ab_tool/views/intervention_point_pages.py
@@ -158,7 +158,7 @@ def edit_intervention_point_common(request, intervention_point_id):
     notes = post_param(request, "notes")
     intervention_point.update(name=name, notes=notes)
     # Validates URLs using backend rules before any InterventionPointUrl object creation
-    intervention_pointurls = [(k,validate_format_url(v)) for (k,v) in request.POST.iteritems() if STAGE_URL_TAG in k and v]
+    intervention_pointurls = [(k,validate_format_url(v.strip())) for (k,v) in request.POST.iteritems() if STAGE_URL_TAG in k and v]
     for (k,v) in intervention_pointurls:
         _, track_id = k.split(STAGE_URL_TAG)
         # This is a search for the joint unique index of InterventionPointUrl, so it


### PR DESCRIPTION
TLT-923: Fixed regex in preview JS to also handle upper case in different sections of the intervention URLs and be consistent with the validation and also fixed the code to strip empty spaces before validating/saving URL in the backend.