### PR TITLE
Bugfix/eparker/tlt 949 download file is not showing all students in the course

### DIFF
--- a/ab_tool/canvas.py
+++ b/ab_tool/canvas.py
@@ -2,6 +2,7 @@ from canvas_sdk.methods.courses import list_users_in_course_users
 from canvas_sdk.methods import modules
 from canvas_sdk import RequestContext
 from canvas_sdk.exceptions import CanvasAPIError
+from canvas_sdk.utils import get_all_list_data
 from django.conf import settings
 
 from ab_tool.exceptions import (MISSING_LTI_PARAM, MISSING_LTI_LAUNCH,
@@ -129,8 +130,11 @@ def get_unassigned_students_with_context(request_context, experiment):
     """ Returns a list of sis_user_ids because that is the unique
         identifier the ab_tool users for students """
     try:
-        enrollments = list_users_in_course_users(
-                request_context, experiment.course_id, None, enrollment_type="student").json()
+        """
+        Part of TLT-949 add get_all_list_data call to get the full list of students in the course
+        """
+        enrollments = get_all_list_data(request_context, list_users_in_course_users, experiment.course_id, None, enrollment_type="student")
+
     except CanvasAPIError as exception:
         handle_canvas_error(exception)
     existing_student_ids = set(s.student_id for s in experiment.students.all())

--- a/ab_tool/canvas.py
+++ b/ab_tool/canvas.py
@@ -7,7 +7,6 @@ from django.conf import settings
 
 from ab_tool.exceptions import (MISSING_LTI_PARAM, MISSING_LTI_LAUNCH,
     NO_SDK_RESPONSE, NoValidCredentials, UNAUTHORIZED_ACCESS)
-from requests.exceptions import RequestException
 from django_canvas_oauth import get_token
 from ab_tool.controllers import intervention_point_url
 from ab_tool.models import InterventionPoint, Experiment, CourseNotification

--- a/ab_tool/tests/test_spreadsheets.py
+++ b/ab_tool/tests/test_spreadsheets.py
@@ -1,0 +1,96 @@
+from ab_tool.tests.common import (SessionTestCase, APIReturn,
+    LIST_MODULES, LIST_ITEMS, TEST_COURSE_ID, TEST_OTHER_COURSE_ID)
+
+from ab_tool.spreadsheets import (get_student_list_csv, get_intervention_point_interactions_csv,
+                                  get_track_selection_xlsx, get_track_selection_csv, parse_uploaded_file, parse_row)
+
+from ab_tool.models import (InterventionPoint, InterventionPointUrl,
+    ExperimentStudent, Experiment, InterventionPointInteraction)
+
+from ab_tool.tests.common import (SessionTestCase, TEST_COURSE_ID,
+    TEST_OTHER_COURSE_ID, NONEXISTENT_INTERVENTION_POINT_ID, APIReturn, LIST_MODULES,
+    TEST_STUDENT_ID)
+
+from ab_tool.exceptions import (MISSING_LTI_LAUNCH, MISSING_LTI_PARAM,
+    NO_SDK_RESPONSE)
+
+from mock import patch, MagicMock, ANY
+from django_canvas_oauth.exceptions import NewTokenNeeded
+
+from canvas_sdk.exceptions import CanvasAPIError
+
+import re
+
+TEST_FILE_TITLE = "test.xslx"
+
+class TestSpreadsheets(SessionTestCase):
+
+    def setUp(self):
+
+
+        self.experiment = Experiment.get_placeholder_course_experiment(TEST_COURSE_ID)
+        self.experiment.update(tracks_finalized=True)
+        self.intervention_point = self.create_test_intervention_point(name="intervention_point1", experiment=self.experiment)
+        self.track1 = self.create_test_track(name="track1", experiment=self.experiment)
+        self.intervention_point2 = self.create_test_intervention_point(name="intervention_point2", experiment=self.experiment)
+        self.track2 = self.create_test_track(name="track2", experiment=self.experiment)
+
+
+
+        self.student = ExperimentStudent.objects.create(course_id=TEST_COURSE_ID, experiment=self.experiment,
+                                         student_id=TEST_STUDENT_ID, track=self.track1)
+
+        InterventionPointUrl.objects.create(intervention_point=self.intervention_point, track=self.track1,
+                                            url="http://www.example.com")
+
+        InterventionPointUrl.objects.create(intervention_point=self.intervention_point2, track=self.track2,
+                                            url="http://www.incorrect-domain.com")
+
+        #self.student = ExperimentStudent.objects.create(course_id=TEST_COURSE_ID, student_id=TEST_STUDENT_ID,
+        #                                 track=self.track1, experiment=self.experiment)
+        #self.intervention_point = self.create_test_intervention_point(course_id=TEST_COURSE_ID)
+
+        InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=self.student,
+                    intervention_point=self.intervention_point, experiment=self.experiment,
+                    track=self.track1, url="http://example.com")
+
+        # InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=self.student,
+        #             intervention_point=self.intervention_point, experiment=self.experiment,
+        #             track=self.track2, url="http://example.com")
+
+
+
+    def mock_api_exception(self):
+        exception = CanvasAPIError()
+        exception.response = MagicMock()
+        return exception
+
+    def mock_unauthorized_exception(self):
+        exception = CanvasAPIError()
+        exception.response = MagicMock()
+        exception.status_code = 401
+        return exception
+
+    def test_get_student_list_csv(self):
+        response = get_student_list_csv(self.experiment, TEST_FILE_TITLE)
+        streaming_list = list(response.streaming_content)
+        self.assertTrue(streaming_list[1].find(TEST_STUDENT_ID) > 0, "TEST_STUDENT_ID not in response")
+        self.assertEqual(streaming_list, [ANY, ANY])
+
+    def test_get_intervention_point_interactions_csv(self):
+        response = get_intervention_point_interactions_csv(self.experiment, TEST_FILE_TITLE)
+        streaming_list = list(response.streaming_content)
+        self.assertTrue(streaming_list[1].find(TEST_STUDENT_ID) > 0, "TEST_STUDENT_ID not in response")
+        self.assertEqual(streaming_list, [ANY, ANY])
+
+    def test_get_track_selection_xlsx(self):
+        self.assertTrue(True)
+
+    def test_get_track_selection_csv(self):
+        self.assertTrue(True)
+
+    def test_parse_uploaded_file(self):
+        self.assertTrue(True)
+
+    def test_parse_row(self):
+        self.assertTrue(True)

--- a/ab_tool/tests/test_spreadsheets.py
+++ b/ab_tool/tests/test_spreadsheets.py
@@ -11,9 +11,13 @@ from django.test import RequestFactory
 from mock import patch, MagicMock, ANY, Mock
 from error_middleware.exceptions import Renderable404
 
+'''
+Setup some test data
+'''
+TEST_XLS_FILE_NAME = "test.xls"
 TEST_XLSX_FILE_NAME = "test.xlsx"
 TEST_CSV_FILE_NAME = "test.csv"
-TEST_DOMAIN = "example.com"
+TEST_DOMAIN = "http://www.example.com"
 TEST_STUDENT_EMAIL = "student@example.com"
 TEST_STUDENT_DICT = {'10123478' : 'Lisa',
                      '20123278' : 'Jan',
@@ -22,6 +26,7 @@ TEST_STUDENT_DICT = {'10123478' : 'Lisa',
                      }
 TEST_CONTENT_TYPE = [('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
                      ('Content-Disposition', 'attachment; filename=test.xlsx')]
+
 TEST_TRACK_SELECTION_RESPONSE = ['Student Name,Student ID,Experiment,Assigned Track\r\n',
                                  'Bob,40212478,Experiment 1,\r\n',
                                  'Jan,20123278,Experiment 1,\r\n',
@@ -35,55 +40,72 @@ class TestSpreadsheets(SessionTestCase):
 
         self.request = RequestFactory().get('/fake-path')
         self.request.user = Mock(name='user_mock')
-        self.request.session = {   "oauth_return_uri": TEST_DOMAIN,
-                                                "LTI_LAUNCH" : {
-                                                     "custom_canvas_api_domain" : TEST_DOMAIN,
-                                                     "lis_person_contact_email_primary" : TEST_STUDENT_EMAIL,
-                                                     "custom_canvas_course_id" : TEST_COURSE_ID,
-                                                     },
-                                            }
+        self.request.session = { "oauth_return_uri": TEST_DOMAIN,
+                                 "LTI_LAUNCH" : {
+                                     "custom_canvas_api_domain" : TEST_DOMAIN,
+                                     "lis_person_contact_email_primary" : TEST_STUDENT_EMAIL,
+                                     "custom_canvas_course_id" : TEST_COURSE_ID,
+                                     },
+                                }
 
         self.experiment = Experiment.get_placeholder_course_experiment(TEST_COURSE_ID)
         self.experiment.update(tracks_finalized=True)
-        self.intervention_point = self.create_test_intervention_point(name="intervention_point1", experiment=self.experiment)
-        self.track1 = self.create_test_track(name="track1", experiment=self.experiment)
-        self.intervention_point2 = self.create_test_intervention_point(name="intervention_point2", experiment=self.experiment)
-        self.track2 = self.create_test_track(name="track2", experiment=self.experiment)
+        self.intervention_point = self.create_test_intervention_point(name="intervention_point1",
+                                                                      experiment=self.experiment)
+        self.track1 = self.create_test_track(name="track1",
+                                             experiment=self.experiment)
 
-        self.student = ExperimentStudent.objects.create(course_id=TEST_COURSE_ID, experiment=self.experiment,
-                                         student_id=TEST_STUDENT_ID, track=self.track1)
+        self.intervention_point2 = self.create_test_intervention_point(name="intervention_point2",
+                                                                       experiment=self.experiment)
+        self.track2 = self.create_test_track(name="track2",
+                                             experiment=self.experiment)
 
-        InterventionPointUrl.objects.create(intervention_point=self.intervention_point, track=self.track1,
-                                            url="http://www.example.com")
+        self.student = ExperimentStudent.objects.create(course_id=TEST_COURSE_ID,
+                                                        experiment=self.experiment,
+                                                        student_id=TEST_STUDENT_ID,
+                                                        track=self.track1)
 
-        InterventionPointUrl.objects.create(intervention_point=self.intervention_point2, track=self.track2,
+        InterventionPointUrl.objects.create(intervention_point=self.intervention_point,
+                                            track=self.track1,
+                                            url=TEST_DOMAIN)
+
+        InterventionPointUrl.objects.create(intervention_point=self.intervention_point2,
+                                            track=self.track2,
                                             url="http://www.incorrect-domain.com")
 
-        InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=self.student,
-                    intervention_point=self.intervention_point, experiment=self.experiment,
-                    track=self.track1, url="http://example.com")
+        InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID,
+                                                    student=self.student,
+                                                    intervention_point=self.intervention_point,
+                                                    experiment=self.experiment,
+                                                    track=self.track1,
+                                                    url=TEST_DOMAIN)
 
 
     def test_get_student_list_csv(self):
         """
-
+        Test that get_student_list_csv returns the correct data from the supplied experiment.
         """
         response = get_student_list_csv(self.experiment, TEST_XLSX_FILE_NAME)
         streaming_list = list(response.streaming_content)
         self.assertTrue(TEST_STUDENT_ID in streaming_list[1])
+        self.assertTrue("Experiment 1" in streaming_list[1])
+        self.assertTrue("track1" in streaming_list[1])
 
     def test_get_intervention_point_interactions_csv(self):
         """
-
+        Test that get_intervention_point_interactions_csv returned the correct data
+        from the supplied experiment
         """
         response = get_intervention_point_interactions_csv(self.experiment, TEST_XLSX_FILE_NAME)
         streaming_list = list(response.streaming_content)
+        self.assertTrue(TEST_STUDENT_ID in streaming_list[1])
+        self.assertTrue("Experiment 1" in streaming_list[1])
         self.assertTrue(TEST_DOMAIN in streaming_list[1])
 
     @patch('ab_tool.spreadsheets.get_unassigned_students')
     def test_get_track_selection_xlsx(self, mock_get_unassigned_students):
         """
-
+        Test that get_track_selection_xlsx returns the correct content type and file name.
         """
         mock_get_unassigned_students.return_value = TEST_STUDENT_DICT
         response = get_track_selection_xlsx(self.request, self.experiment)
@@ -92,7 +114,8 @@ class TestSpreadsheets(SessionTestCase):
     @patch('ab_tool.spreadsheets.get_unassigned_students')
     def test_get_track_selection_csv(self, mock_get_unassigned_students):
         """
-
+        Test that get_track_selection_csv returns the correct data. In this case
+        the streaming list is the data that would be downloaded into a csv file.
         """
         mock_get_unassigned_students.return_value = TEST_STUDENT_DICT
         response = get_track_selection_csv(self.request, self.experiment)
@@ -102,15 +125,27 @@ class TestSpreadsheets(SessionTestCase):
     @patch('ab_tool.spreadsheets.xlrd.open_workbook')
     def test_parse_uploaded_xlsx_file(self, mock_open_workbook):
         """
-
+        Test that parse_uploaded_xlsx_file calls the xlrd.open_workbook method with the
+        appropriate data for files of type xlsx
         """
         result = parse_uploaded_file(self.experiment, TEST_STUDENT_DICT, TEST_TRACK_SELECTION_RESPONSE, TEST_XLSX_FILE_NAME)
         mock_open_workbook.assert_called_with(file_contents=TEST_TRACK_SELECTION_RESPONSE)
 
+    @patch('ab_tool.spreadsheets.xlrd.open_workbook')
+    def test_parse_uploaded_xls_file(self, mock_open_workbook):
+        """
+        Test that parse_uploaded_xlsx_file calls the xlrd.open_workbook method with the
+        appropriate data for files of type xls
+        """
+        result = parse_uploaded_file(self.experiment, TEST_STUDENT_DICT, TEST_TRACK_SELECTION_RESPONSE, TEST_XLS_FILE_NAME)
+        mock_open_workbook.assert_called_with(file_contents=TEST_TRACK_SELECTION_RESPONSE)
+
+
     @patch('ab_tool.spreadsheets.csv.reader')
     def test_parse_uploaded_csv_file(self, mock_csv_reader):
         """
-
+        Test that parse_uploaded_csv_file calls the csv.reader method with the
+        appropriate data for files of type csv
         """
         result = parse_uploaded_file(self.experiment, TEST_STUDENT_DICT,
                                      TEST_TRACK_SELECTION_RESPONSE[1], TEST_CSV_FILE_NAME)
@@ -120,14 +155,14 @@ class TestSpreadsheets(SessionTestCase):
     @patch('ab_tool.spreadsheets.xlrd.open_workbook')
     def test_parse_uploaded_file_invalid_file_name(self, mock_open_workbook):
         """
-
+        Test that parse_uploaded_file raises a Renderable404 when a invalid file type is specified
         """
         self.assertRaises(Renderable404, parse_uploaded_file, self.experiment,
                           TEST_STUDENT_DICT, TEST_TRACK_SELECTION_RESPONSE, "test.xslx")
 
     def test_parse_row(self):
         """
-
+        Test that parse_row populates the student dictionary with the correct values when the supplied data is correct
         """
         students = {}
         errors = []
@@ -139,7 +174,8 @@ class TestSpreadsheets(SessionTestCase):
 
     def test_parse_row_missing_track(self):
         """
-
+        Test that parse_row populates the errors list with the 'missing track name' error message
+        when no track name is supplied
         """
         students = {}
         errors = []
@@ -151,7 +187,8 @@ class TestSpreadsheets(SessionTestCase):
 
     def test_parse_row_invalid_track_name(self):
         """
-
+        Test that parse_row populates the errors list with the 'invalid track name' error message
+        when the supplied track name does not match the tracks in the experiment
         """
         students = {}
         errors = []
@@ -163,7 +200,8 @@ class TestSpreadsheets(SessionTestCase):
 
     def test_parse_row_wrong_experiment_name(self):
         """
-
+        Test that parse_row populates the errors list with the 'wrong experiment name' error message
+        when an invalid experiemnt name is supplied
         """
         students = {}
         errors = []
@@ -173,15 +211,28 @@ class TestSpreadsheets(SessionTestCase):
         parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
         self.assertEqual(errors, ["Row 1: wrong experiment name 'Experiment 2'"])
 
-    def test_parse_row_student_not_available_for_assignment(self):
+    def test_parse_row_missing_row(self):
         """
-
+        Test that parse_row returns None when row is None
         """
         students = {}
         errors = []
         tracks = {track.name: track for track in self.experiment.tracks.all()}
-        row = ['Fred','50123278','Experiment 1', 'track2']
+        row = None
+        row_number = 1
+        result = parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
+        self.assertEqual(result, None)
+
+    def test_parse_row_student_not_available_for_assignment(self):
+        """
+        Test that parse_row populates the errors list with the 'student x not available for assignment' error message
+        when the student is not in the supplied list of valid students
+        """
+        students = {}
+        errors = []
+        tracks = {track.name: track for track in self.experiment.tracks.all()}
+        row = ['student_a','50123278','Experiment 1', 'track2']
         row_number = 1
         parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
-        self.assertEqual(errors, ["Row 1: student 'Fred' not available for assignment"])
+        self.assertEqual(errors, ["Row 1: student 'student_a' not available for assignment"])
 

--- a/ab_tool/tests/test_spreadsheets.py
+++ b/ab_tool/tests/test_spreadsheets.py
@@ -1,32 +1,47 @@
-from ab_tool.tests.common import (SessionTestCase, APIReturn,
-    LIST_MODULES, LIST_ITEMS, TEST_COURSE_ID, TEST_OTHER_COURSE_ID)
 
 from ab_tool.spreadsheets import (get_student_list_csv, get_intervention_point_interactions_csv,
-                                  get_track_selection_xlsx, get_track_selection_csv, parse_uploaded_file, parse_row)
+                                  get_track_selection_xlsx, get_track_selection_csv,
+                                  parse_uploaded_file, parse_row)
+from ab_tool.models import (InterventionPointUrl, ExperimentStudent, Experiment,
+                            InterventionPointInteraction)
 
-from ab_tool.models import (InterventionPoint, InterventionPointUrl,
-    ExperimentStudent, Experiment, InterventionPointInteraction)
+from ab_tool.tests.common import (SessionTestCase, TEST_COURSE_ID, TEST_STUDENT_ID)
 
-from ab_tool.tests.common import (SessionTestCase, TEST_COURSE_ID,
-    TEST_OTHER_COURSE_ID, NONEXISTENT_INTERVENTION_POINT_ID, APIReturn, LIST_MODULES,
-    TEST_STUDENT_ID)
+from django.test import RequestFactory
+from mock import patch, MagicMock, ANY, Mock
+from error_middleware.exceptions import Renderable404
 
-from ab_tool.exceptions import (MISSING_LTI_LAUNCH, MISSING_LTI_PARAM,
-    NO_SDK_RESPONSE)
+TEST_XLSX_FILE_NAME = "test.xlsx"
+TEST_CSV_FILE_NAME = "test.csv"
+TEST_DOMAIN = "example.com"
+TEST_STUDENT_EMAIL = "student@example.com"
+TEST_STUDENT_DICT = {'10123478' : 'Lisa',
+                     '20123278' : 'Jan',
+                     '34512278' : 'Pete',
+                     '40212478' : 'Bob',
+                     }
+TEST_CONTENT_TYPE = [('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+                     ('Content-Disposition', 'attachment; filename=test.xlsx')]
+TEST_TRACK_SELECTION_RESPONSE = ['Student Name,Student ID,Experiment,Assigned Track\r\n',
+                                 'Bob,40212478,Experiment 1,\r\n',
+                                 'Jan,20123278,Experiment 1,\r\n',
+                                 'Lisa,10123478,Experiment 1,\r\n',
+                                 'Pete,34512278,Experiment 1,\r\n']
 
-from mock import patch, MagicMock, ANY
-from django_canvas_oauth.exceptions import NewTokenNeeded
-
-from canvas_sdk.exceptions import CanvasAPIError
-
-import re
-
-TEST_FILE_TITLE = "test.xslx"
 
 class TestSpreadsheets(SessionTestCase):
 
     def setUp(self):
 
+        self.request = RequestFactory().get('/fake-path')
+        self.request.user = Mock(name='user_mock')
+        self.request.session = {   "oauth_return_uri": TEST_DOMAIN,
+                                                "LTI_LAUNCH" : {
+                                                     "custom_canvas_api_domain" : TEST_DOMAIN,
+                                                     "lis_person_contact_email_primary" : TEST_STUDENT_EMAIL,
+                                                     "custom_canvas_course_id" : TEST_COURSE_ID,
+                                                     },
+                                            }
 
         self.experiment = Experiment.get_placeholder_course_experiment(TEST_COURSE_ID)
         self.experiment.update(tracks_finalized=True)
@@ -34,8 +49,6 @@ class TestSpreadsheets(SessionTestCase):
         self.track1 = self.create_test_track(name="track1", experiment=self.experiment)
         self.intervention_point2 = self.create_test_intervention_point(name="intervention_point2", experiment=self.experiment)
         self.track2 = self.create_test_track(name="track2", experiment=self.experiment)
-
-
 
         self.student = ExperimentStudent.objects.create(course_id=TEST_COURSE_ID, experiment=self.experiment,
                                          student_id=TEST_STUDENT_ID, track=self.track1)
@@ -46,51 +59,129 @@ class TestSpreadsheets(SessionTestCase):
         InterventionPointUrl.objects.create(intervention_point=self.intervention_point2, track=self.track2,
                                             url="http://www.incorrect-domain.com")
 
-        #self.student = ExperimentStudent.objects.create(course_id=TEST_COURSE_ID, student_id=TEST_STUDENT_ID,
-        #                                 track=self.track1, experiment=self.experiment)
-        #self.intervention_point = self.create_test_intervention_point(course_id=TEST_COURSE_ID)
-
         InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=self.student,
                     intervention_point=self.intervention_point, experiment=self.experiment,
                     track=self.track1, url="http://example.com")
 
-        # InterventionPointInteraction.objects.create(course_id=TEST_COURSE_ID, student=self.student,
-        #             intervention_point=self.intervention_point, experiment=self.experiment,
-        #             track=self.track2, url="http://example.com")
-
-
-
-    def mock_api_exception(self):
-        exception = CanvasAPIError()
-        exception.response = MagicMock()
-        return exception
-
-    def mock_unauthorized_exception(self):
-        exception = CanvasAPIError()
-        exception.response = MagicMock()
-        exception.status_code = 401
-        return exception
 
     def test_get_student_list_csv(self):
-        response = get_student_list_csv(self.experiment, TEST_FILE_TITLE)
+        """
+
+        """
+        response = get_student_list_csv(self.experiment, TEST_XLSX_FILE_NAME)
         streaming_list = list(response.streaming_content)
-        self.assertTrue(streaming_list[1].find(TEST_STUDENT_ID) > 0, "TEST_STUDENT_ID not in response")
-        self.assertEqual(streaming_list, [ANY, ANY])
+        self.assertTrue(TEST_STUDENT_ID in streaming_list[1])
 
     def test_get_intervention_point_interactions_csv(self):
-        response = get_intervention_point_interactions_csv(self.experiment, TEST_FILE_TITLE)
+        """
+
+        """
+        response = get_intervention_point_interactions_csv(self.experiment, TEST_XLSX_FILE_NAME)
         streaming_list = list(response.streaming_content)
-        self.assertTrue(streaming_list[1].find(TEST_STUDENT_ID) > 0, "TEST_STUDENT_ID not in response")
-        self.assertEqual(streaming_list, [ANY, ANY])
+        self.assertTrue(TEST_DOMAIN in streaming_list[1])
 
-    def test_get_track_selection_xlsx(self):
-        self.assertTrue(True)
+    @patch('ab_tool.spreadsheets.get_unassigned_students')
+    def test_get_track_selection_xlsx(self, mock_get_unassigned_students):
+        """
 
-    def test_get_track_selection_csv(self):
-        self.assertTrue(True)
+        """
+        mock_get_unassigned_students.return_value = TEST_STUDENT_DICT
+        response = get_track_selection_xlsx(self.request, self.experiment)
+        self.assertEqual(response.items(), TEST_CONTENT_TYPE)
 
-    def test_parse_uploaded_file(self):
-        self.assertTrue(True)
+    @patch('ab_tool.spreadsheets.get_unassigned_students')
+    def test_get_track_selection_csv(self, mock_get_unassigned_students):
+        """
+
+        """
+        mock_get_unassigned_students.return_value = TEST_STUDENT_DICT
+        response = get_track_selection_csv(self.request, self.experiment)
+        streaming_list = list(response.streaming_content)
+        self.assertEqual(streaming_list, TEST_TRACK_SELECTION_RESPONSE)
+
+    @patch('ab_tool.spreadsheets.xlrd.open_workbook')
+    def test_parse_uploaded_xlsx_file(self, mock_open_workbook):
+        """
+
+        """
+        result = parse_uploaded_file(self.experiment, TEST_STUDENT_DICT, TEST_TRACK_SELECTION_RESPONSE, TEST_XLSX_FILE_NAME)
+        mock_open_workbook.assert_called_with(file_contents=TEST_TRACK_SELECTION_RESPONSE)
+
+    @patch('ab_tool.spreadsheets.csv.reader')
+    def test_parse_uploaded_csv_file(self, mock_csv_reader):
+        """
+
+        """
+        result = parse_uploaded_file(self.experiment, TEST_STUDENT_DICT,
+                                     TEST_TRACK_SELECTION_RESPONSE[1], TEST_CSV_FILE_NAME)
+        data = TEST_TRACK_SELECTION_RESPONSE[1].split("\n")[1:]
+        mock_csv_reader.assert_called_with(data)
+
+    @patch('ab_tool.spreadsheets.xlrd.open_workbook')
+    def test_parse_uploaded_file_invalid_file_name(self, mock_open_workbook):
+        """
+
+        """
+        self.assertRaises(Renderable404, parse_uploaded_file, self.experiment,
+                          TEST_STUDENT_DICT, TEST_TRACK_SELECTION_RESPONSE, "test.xslx")
 
     def test_parse_row(self):
-        self.assertTrue(True)
+        """
+
+        """
+        students = {}
+        errors = []
+        tracks = {track.name: track for track in self.experiment.tracks.all()}
+        row = ['Jan','20123278','Experiment 1', 'track1']
+        row_number = 1
+        parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
+        self.assertEqual(students.keys(), ['20123278'])
+
+    def test_parse_row_missing_track(self):
+        """
+
+        """
+        students = {}
+        errors = []
+        tracks = {track.name: track for track in self.experiment.tracks.all()}
+        row = ['Jan','20123278','Experiment 1', ]
+        row_number = 1
+        parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
+        self.assertEqual(errors, ["Row 1: missing track name"])
+
+    def test_parse_row_invalid_track_name(self):
+        """
+
+        """
+        students = {}
+        errors = []
+        tracks = {track.name: track for track in self.experiment.tracks.all()}
+        row = ['Jan','20123278','Experiment 1', 'track3']
+        row_number = 1
+        parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
+        self.assertEqual(errors, ["Row 1: invalid track name 'track3'"])
+
+    def test_parse_row_wrong_experiment_name(self):
+        """
+
+        """
+        students = {}
+        errors = []
+        tracks = {track.name: track for track in self.experiment.tracks.all()}
+        row = ['Jan','20123278','Experiment 2', 'track2']
+        row_number = 1
+        parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
+        self.assertEqual(errors, ["Row 1: wrong experiment name 'Experiment 2'"])
+
+    def test_parse_row_student_not_available_for_assignment(self):
+        """
+
+        """
+        students = {}
+        errors = []
+        tracks = {track.name: track for track in self.experiment.tracks.all()}
+        row = ['Fred','50123278','Experiment 1', 'track2']
+        row_number = 1
+        parse_row(row, row_number, self.experiment, tracks, TEST_STUDENT_DICT, students, errors)
+        self.assertEqual(errors, ["Row 1: student 'Fred' not available for assignment"])
+

--- a/ab_tool/tests/test_spreadsheets.py
+++ b/ab_tool/tests/test_spreadsheets.py
@@ -42,12 +42,13 @@ class TestSpreadsheets(SessionTestCase):
     def setUp(self):
         self.request = RequestFactory().get('/fake-path')
         self.request.user = Mock(name='user_mock')
-        self.request.session = {'oauth_return_uri': TEST_DOMAIN,
-                                'LTI_LAUNCH': {
-                                    'custom_canvas_api_domain': TEST_DOMAIN,
-                                    'lis_person_contact_email_primary': TEST_STUDENT_EMAIL,
-                                    'custom_canvas_course_id': TEST_COURSE_ID,
-                                },
+        self.request.session = {
+            'oauth_return_uri': TEST_DOMAIN,
+            'LTI_LAUNCH': {
+                'custom_canvas_api_domain': TEST_DOMAIN,
+                'lis_person_contact_email_primary': TEST_STUDENT_EMAIL,
+                'custom_canvas_course_id': TEST_COURSE_ID,
+            },
         }
 
         self.experiment = Experiment.get_placeholder_course_experiment(TEST_COURSE_ID)


### PR DESCRIPTION
First off, I know this is a bugfix and technically should be merged to master. However, I goofed and created this branch from develop, so I'm going to merge back to develop. Since we are all adding to develop and that will become the new master when we release I don't' see any issues with that. If you do please let me know.

This fixes bug that was causing the download file to not show all the students in the course. The bug fix was easy, we just needed to wrap the SDK call to get the enrollment data in the SDK util method get_all_list_data. The straight call to get enrollments was not following the next url to get the next page of students. The get_all_list_data util method take the call (any call really) as an argument and automatically follows the next url to retrieve the full list. This is what the code looks like now:
```
enrollments = get_all_list_data(request_context, list_users_in_course_users, 
                                experiment.course_id, None, enrollment_type="student")
```
This PR also includes unit tests for the spreadsheet module. There were previously no unit tests for this module. My last run of coverage shows we are getting 97% of the code now. 