### PR TITLE
include updated_on in the list of fields updated by update()

### DIFF
--- a/ab_tool/models.py
+++ b/ab_tool/models.py
@@ -20,9 +20,11 @@ class TimestampedModel(models.Model):
     
     def update(self, **kwargs):
         """ Helper method to update objects """
+        update_fields = {'updated_on'}
         for k, v in kwargs.iteritems():
             setattr(self, k, v)
-        self.save(update_fields=kwargs.keys())
+            update_fields.add(k)
+        self.save(update_fields=update_fields)
     
     def save_as_new_object(self, **kwargs):
         """ Saves a new object based on the original, applying updates in

--- a/ab_tool/tests/test_experiment_pages.py
+++ b/ab_tool/tests/test_experiment_pages.py
@@ -72,6 +72,20 @@ class TestExperimentPages(SessionTestCase):
         experiment = self.create_test_experiment(course_id=TEST_OTHER_COURSE_ID)
         response = self.client.get(reverse("ab_testing_tool_edit_experiment", args=(experiment.id,)))
         self.assertError(response, UNAUTHORIZED_ACCESS)
+
+    def test_edit_experiment_view_last_modified_updated(self):
+        """ Tests edit_experiment to confirm that the last updated timestamp changes """
+        experiment = self.create_test_experiment()
+        experiment.name += " (updated)"
+        response = self.client.post(reverse("ab_testing_tool_submit_edit_experiment",
+                                            args=(experiment.id,)),
+                                    content_type="application/json",
+                                    data=experiment.to_json())
+        self.assertEquals(response.content, "success")
+        updated_experiment = Experiment.objects.get(id=experiment.id)
+        self.assertLess(experiment.updated_on, updated_experiment.updated_on,
+                        response)
+
     
     def test_submit_create_experiment(self):
         """ Tests that create_experiment creates a Experiment object verified by


### PR DESCRIPTION
If we're going to use a helper method to cherry-pick specific fields we
want to update on an instance, we have to make sure we tell django it's
okay to update the updated_on field as well.

Includes unit test to verify that updated_on changes when an experiment
is edited.