### PR TITLE
Bugfix/tlt 1061/eparker/create experiment spreadsheet upload option form submission error

### DIFF
--- a/ab_tool/tests/test_experiment_pages.py
+++ b/ab_tool/tests/test_experiment_pages.py
@@ -88,7 +88,23 @@ class TestExperimentPages(SessionTestCase):
             content_type="application/json", data=json.dumps(experiment)
         )
         self.assertEquals(num_experiments + 1, Experiment.objects.count(), response)
-    
+
+    def test_submit_create_experiment_csv_upload(self):
+        """ Tests that create_experiment creates a Experiment object verified by
+            DB count when csvUpload is True and no track weights are specified"""
+        Experiment.get_placeholder_course_experiment(TEST_COURSE_ID)
+        num_experiments = Experiment.objects.count()
+        experiment = {
+                "name": "experiment", "notes": "hi", "uniformRandom": False,
+                "csvUpload": True,
+                "tracks": [{"id": None, "name": "A"}]
+        }
+        response = self.client.post(
+            reverse("ab_testing_tool_submit_create_experiment"), follow=True,
+            content_type="application/json", data=json.dumps(experiment)
+        )
+        self.assertEquals(num_experiments + 1, Experiment.objects.count(), response)
+
     def test_submit_create_experiment_with_weights_as_assignment_method(self):
         """ Tests that create_experiment creates a Experiment object verified by
             DB count when uniformRandom is false and the tracks have weightings """

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -49,6 +49,8 @@ def submit_create_experiment(request):
     # Validates using backend rules before any object creation
     for track_dict in tracks:
         validate_name(track_dict["name"])
+        # added check for csv upload. if we are uploading a csv file
+        # we don't want track weights
         if not uniform_random and not csv_upload:
             validate_weighting(track_dict["weighting"])
 

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -50,7 +50,7 @@ def submit_create_experiment(request):
     for track_dict in tracks:
         validate_name(track_dict["name"])
         # added check for csv upload. if we are uploading a csv file
-        # we don't want track weights
+        # we don't want track weights bl;ajisdpoifapsdoifapsdo
         if not uniform_random and not csv_upload:
             validate_weighting(track_dict["weighting"])
 

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -38,19 +38,20 @@ def submit_create_experiment(request):
     """
     course_id = get_lti_param(request, "custom_canvas_course_id")
     experiment_dict = json.loads(request.body)
-    
+
     # Unpack data from experiment_dict and update experiment
     name = validate_name(experiment_dict["name"])
     notes = experiment_dict["notes"]
     uniform_random = bool(experiment_dict["uniformRandom"])
     tracks = experiment_dict["tracks"]
+    csv_upload = bool(experiment_dict["csvUpload"])
+
     # Validates using backend rules before any object creation
     for track_dict in tracks:
         validate_name(track_dict["name"])
-        if not uniform_random:
+        if not uniform_random and not csv_upload:
             validate_weighting(track_dict["weighting"])
-    
-    csv_upload = experiment_dict["csvUpload"]
+
     if csv_upload:
         assignment_method = Experiment.CSV_UPLOAD
     elif uniform_random:

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -50,7 +50,7 @@ def submit_create_experiment(request):
     for track_dict in tracks:
         validate_name(track_dict["name"])
         # added check for csv upload. if we are uploading a csv file
-        # we don't want track weights bl;ajisdpoifapsdoifapsdo
+        # we don't want track weights
         if not uniform_random and not csv_upload:
             validate_weighting(track_dict["weighting"])
 


### PR DESCRIPTION
An error was occurring when a user tried to create an experiment with the 'Upload a spreadsheet of student track assignments' option selected and the option 'Equally weight each track (uniform random)' unselected and no weights input into the tracks. If a user chooses to upload a csv they will assign the tracks manually. There was a check in the view that checked for the weights of tracks even if they were going to be manually set. I added a check for csv upload to the block that performed the weight check. Now no weight weight check with occur with csv uploads. I confirmed with Marlee and this is how it's supposed to be. The relavent code is below starting at line 52.
```
        # added check for csv upload. if we are uploading a csv file
        # we don't want track weights bl;ajisdpoifapsdoifapsdo
        if not uniform_random and not csv_upload:
            validate_weighting(track_dict["weighting"])
```
