### PR TITLE
Sprint 18 TLT-985 Add django-sslserver

### DIFF
--- a/ab_testing_tool/requirements/local.txt
+++ b/ab_testing_tool/requirements/local.txt
@@ -4,3 +4,5 @@
 -r base.txt 
  
 # below are requirements specific to the local environment
+django-debug-toolbar
+django-sslserver==0.14

--- a/ab_testing_tool/settings/local.py
+++ b/ab_testing_tool/settings/local.py
@@ -1,1 +1,3 @@
 from .base import *
+
+INSTALLED_APPS += ('debug_toolbar', 'sslserver')


### PR DESCRIPTION
@elliottyates 
@eparker71 

I was not able to get ab-testing-tool to run locally without running django-sslserver.