### PR TITLE
Sprint 19 TLT-877 Fix csv upload unit test

### DIFF
--- a/ab_testing_tool/settings/test_settings.py
+++ b/ab_testing_tool/settings/test_settings.py
@@ -12,7 +12,8 @@ if not ENV_SETTINGS.get('enable_test_logging'):
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
-        'TEST_NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
+        'TEST': {
+            'NAME': os.path.join(BASE_DIR, 'test.sqlite3'),
+        }
     },
 }

--- a/ab_testing_tool/settings/test_settings.py
+++ b/ab_testing_tool/settings/test_settings.py
@@ -7,3 +7,12 @@ from .base import *
 if not ENV_SETTINGS.get('enable_test_logging'):
     for logger in LOGGING['loggers']:
         LOGGING['loggers'][logger]['handlers'] = ['null']
+
+# make tests faster
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
+        'TEST_NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
+    },
+}

--- a/ab_tool/tests/test_spreadsheets.py
+++ b/ab_tool/tests/test_spreadsheets.py
@@ -33,6 +33,12 @@ TEST_TRACK_SELECTION_RESPONSE = ['Student Name,Student ID,Experiment,Assigned Tr
                                  'StudentA,10123478,Experiment 1,\r\n',
                                  'StudentC,34512278,Experiment 1,\r\n']
 
+TEST_TRACK_SELECTION_UPLOAD = ['Student Name,Student ID,Experiment,Assigned Track\r\n',
+                                 'StudentD,40212478,Experiment 1,track1\r\n',
+                                 'StudentB,20123278,Experiment 1,track1\r\n',
+                                 'StudentA,10123478,Experiment 1,track1\r\n',
+                                 'StudentC,34512278,Experiment 1,track1\r\n']
+
 TEST_ROW = [TEST_STUDENT_DICT['20123278'], '20123278', 'Experiment 1', 'track1']
 
 TEST_ROW_NUMBER = 1
@@ -143,22 +149,17 @@ class TestSpreadsheets(SessionTestCase):
         parse_uploaded_file(self.experiment, TEST_STUDENT_DICT, TEST_TRACK_SELECTION_RESPONSE, TEST_XLS_FILE_NAME)
         mock_open_workbook.assert_called_with(file_contents=TEST_TRACK_SELECTION_RESPONSE)
 
-    @patch('ab_tool.spreadsheets.csv.reader')
     @patch('ab_tool.spreadsheets.parse_row')
-    def test_parse_uploaded_csv_file(self, mock_parse_row, mock_csv_reader):
+    def test_parse_uploaded_csv_file(self, mock_parse_row):
         """
         Test that parse_uploaded_csv_file calls the csv.reader method with the
         appropriate data for files of type csv
         """
-        new_row = ','.join(TEST_ROW)
-        mock_csv_reader.return_value = [new_row]
         tracks = {track.name: track for track in self.experiment.tracks.all()}
         parse_uploaded_file(self.experiment, TEST_STUDENT_DICT,
-                            TEST_TRACK_SELECTION_RESPONSE[1],
+                            ''.join(TEST_TRACK_SELECTION_UPLOAD[0:3]),
                             TEST_CSV_FILE_NAME)
-        data = TEST_TRACK_SELECTION_RESPONSE[1].split('\n')[1:]
-        mock_csv_reader.assert_called_with(data)
-        mock_parse_row.assert_called_with(new_row, 2,
+        mock_parse_row.assert_called_with(TEST_ROW, TEST_ROW_NUMBER + 2,
                                           self.experiment, tracks,
                                           TEST_STUDENT_DICT, {}, [])
 


### PR DESCRIPTION
@elliottyates 
@rascalking

Looks like I broke one of the unit tests with #170. The problem was with the mocked csv.reader and the fact that the mock object doesn't have a .next method implemented. With this PR I am removing the mocking of csv.reader (seems like a bad idea to mock 3rd party packages). I'm somewhat new to mock, so let me know if I'm not making sense here.

Also, I modified test_settings to make sure we are using sqlite for the test database.