### PR TITLE
Task/elliottyates/tlt 1042/enable csrf protection

### DIFF
--- a/ab_testing_tool/settings/base.py
+++ b/ab_testing_tool/settings/base.py
@@ -69,9 +69,9 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    # Disabling these removes the need for @xframe_options_exempt, @csrf_exempt on views
-    # TODO: determine if this is a better way to go about this
-    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    # Disabling this removes the need for @xframe_options_exempt on views
+    # TODO: determine if there is a better way to prevent clickjacking within an iframe context
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_auth_lti.middleware.LTIAuthMiddleware',
     'error_middleware.middleware.ErrorMiddleware',

--- a/ab_tool/static/ab_tool/js/edit_experiment.js
+++ b/ab_tool/static/ab_tool/js/edit_experiment.js
@@ -286,5 +286,9 @@ var controller = function($scope, $window, $http) {
 /**
  * Angular module configuration
  */
-angular.module('ABToolExperiment', []).
-    controller('experimentController', controller);
+var app = angular.module('ABToolExperiment', []);
+app.controller('experimentController', controller);
+app.config(['$httpProvider', function($httpProvider) {
+    $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+    $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+}]);

--- a/ab_tool/templates/ab_tool/add_module_item.html
+++ b/ab_tool/templates/ab_tool/add_module_item.html
@@ -13,7 +13,7 @@
     <main>
         {% if intervention_points %}
         <form class="form-horizontal" method="POST" action="{% url 'ab_testing_tool_submit_selection' %}">
-
+            {% csrf_token %}
             <fieldset  class="fieldset-noborder">
                 <legend class="sr-only">Tracks for experiment</legend>
 

--- a/ab_tool/templates/ab_tool/edit_intervention_point_from_canvas.html
+++ b/ab_tool/templates/ab_tool/edit_intervention_point_from_canvas.html
@@ -14,7 +14,7 @@
     <main>
             <form role="form" method="post" class="form-horizontal" name="intervention_point_form"
             action="{% url 'ab_testing_tool_submit_edit_intervention_point_from_modules' intervention_point.id %}">
-            
+                {% csrf_token %}
                 <fieldset>
                     <legend class="sr-only">Name of experiment</legend>
                     

--- a/ab_tool/templates/ab_tool/modals.html
+++ b/ab_tool/templates/ab_tool/modals.html
@@ -56,6 +56,7 @@
         </div>
         <form class="form-horizontal modal-form" role="form" method="post" name="intervention_point_creation_form"
             action="{% url 'ab_testing_tool_submit_create_intervention_point' experiment.id %}">
+            {% csrf_token %}
             <div class="modal-body">
                 <fieldset>
                     <legend class="sr-only">Name of intervention point</legend>
@@ -140,6 +141,7 @@
         </div>
         <form method="post" class="form-horizontal modal-form" name="intervention_point_form"
             action="{% url 'ab_testing_tool_submit_edit_intervention_point' intervention_point.id %}">
+            {% csrf_token %}
             <div class="modal-body">
 
                 <fieldset>
@@ -286,6 +288,7 @@
                 <h4 class="modal-title">Upload Track Assignments</h4>
             </div>
             <form method="post" action="{% url 'ab_testing_tool_upload_track_assignments' experiment.id %}" enctype="multipart/form-data">
+                {% csrf_token %}
                 <div class="modal-body">
                     <p>Upload a spreadsheet to assign students to tracks. Download the following file of all
                     students not assigned to a track, fill it in with track assignments for each student, and

--- a/ab_tool/urls.py
+++ b/ab_tool/urls.py
@@ -3,8 +3,7 @@ from django.conf.urls import patterns, url
 from ab_tool.views.main_pages import (render_control_panel, not_authorized,
     tool_config, download_track_assignments, download_intervention_point_interactions)
 
-from ab_tool.views.selection_pages import (resource_selection, submit_selection,
-    submit_selection_new_intervention_point)
+from ab_tool.views.selection_pages import (resource_selection, submit_selection)
 from ab_tool.views.intervention_point_pages import (submit_create_intervention_point,
     delete_intervention_point, deploy_intervention_point,
     submit_edit_intervention_point, modules_page_edit_intervention_point,
@@ -25,7 +24,8 @@ urlpatterns = patterns('',
     
     url(r'^resource_selection$', resource_selection, name="ab_testing_tool_resource_selection"),
     url(r'^submit_selection$', submit_selection, name="ab_testing_tool_submit_selection"),
-    url(r'^submit_selection_new_intervention_point$', submit_selection_new_intervention_point, name="ab_testing_tool_submit_selection_new_intervention_point"),
+    # TODO: re-enable submit_selection_new_intervention_point() once it is available through the UI
+    # url(r'^submit_selection_new_intervention_point$', submit_selection_new_intervention_point, name="ab_testing_tool_submit_selection_new_intervention_point"),
     
     url(r'^submit_create_intervention_point/(?P<experiment_id>\d+)$', submit_create_intervention_point, name='ab_testing_tool_submit_create_intervention_point'),
     url(r'^modules_page_view_intervention_point/(?P<intervention_point_id>\d+)$', modules_page_view_intervention_point, name='ab_testing_tool_modules_page_view_intervention_point'),

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -85,6 +85,7 @@ def edit_experiment(request, experiment_id):
     return render(request, "ab_tool/edit_experiment.html", context)
 
 
+# TODO: CSRF protection e.g. implement as POST
 @lti_role_required(ADMINS)
 def delete_track(request, track_id):
     """ If Http404 is raised, delete_track redirects regardless. This is by
@@ -152,6 +153,7 @@ def submit_edit_experiment(request, experiment_id):
     return HttpResponse("success")
 
 
+# TODO: CSRF protection e.g. implement as POST
 @lti_role_required(ADMINS)
 def copy_experiment(request, experiment_id):
     course_id = get_lti_param(request, "custom_canvas_course_id")
@@ -166,6 +168,7 @@ def copy_experiment(request, experiment_id):
     raise COPIES_EXCEEDS_LIMIT
 
 
+# TODO: CSRF protection e.g. implement as POST
 @lti_role_required(ADMINS)
 def delete_experiment(request, experiment_id):
     """ If Http404 is raised, delete_experiment redirects regardless. This is by
@@ -183,6 +186,7 @@ def delete_experiment(request, experiment_id):
     return redirect(reverse("ab_testing_tool_index"))
 
 
+# TODO: CSRF protection e.g. implement as POST
 @lti_role_required(ADMINS)
 def finalize_tracks(request, experiment_id):
     course_id = get_lti_param(request, "custom_canvas_course_id")

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -1,5 +1,5 @@
 import json
-from django.shortcuts import render_to_response, redirect
+from django.shortcuts import render_to_response, redirect, render
 from django_auth_lti.decorators import lti_role_required
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -20,7 +20,7 @@ from ab_tool.spreadsheets import (get_track_selection_xlsx, get_track_selection_
 @lti_role_required(ADMINS)
 def create_experiment(request):
     context = {"create": True, "started": False}
-    return render_to_response("ab_tool/edit_experiment.html", context)
+    return render(request, "ab_tool/edit_experiment.html", context)
 
 
 @lti_role_required(ADMINS)
@@ -82,7 +82,7 @@ def edit_experiment(request, experiment_id):
                "experiment_has_installed_intervention": has_installed_intervention,
                "create": False,
                "started": experiment.tracks_finalized}
-    return render_to_response("ab_tool/edit_experiment.html", context)
+    return render(request, "ab_tool/edit_experiment.html", context)
 
 
 @lti_role_required(ADMINS)

--- a/ab_tool/views/intervention_point_pages.py
+++ b/ab_tool/views/intervention_point_pages.py
@@ -186,6 +186,7 @@ def edit_intervention_point_common(request, intervention_point_id):
                                     is_canvas_page=is_canvas_page, open_as_tab=open_as_tab)
 
 
+# TODO: CSRF protection e.g. implement as POST
 @lti_role_required(ADMINS)
 def delete_intervention_point(request, intervention_point_id):
     """ Note: Installed intervention_points are not allowed to be deleted

--- a/ab_tool/views/intervention_point_pages.py
+++ b/ab_tool/views/intervention_point_pages.py
@@ -1,5 +1,6 @@
-from django.shortcuts import render_to_response, redirect
+from django.shortcuts import render_to_response, redirect, render
 from django.core.urlresolvers import reverse
+from django.views.decorators.csrf import csrf_exempt
 from django_auth_lti.decorators import lti_role_required
 
 from ab_tool.constants import (ADMINS, INTERVENTION_POINT_URL_TAG,
@@ -16,6 +17,7 @@ from ab_tool.analytics import log_intervention_point_interaction
 from django.http.response import Http404
 
 
+@csrf_exempt
 def deploy_intervention_point(request, intervention_point_id):
     """
     Delivers randomly one of the urls in intervention_point if user is not an admin,
@@ -113,7 +115,7 @@ def modules_page_view_intervention_point(request, intervention_point_id):
 @lti_role_required(ADMINS)
 def modules_page_edit_intervention_point(request, intervention_point_id):
     context = intervention_point_context(request, intervention_point_id)
-    return render_to_response("ab_tool/edit_intervention_point_from_canvas.html", context)
+    return render(request, "ab_tool/edit_intervention_point_from_canvas.html", context)
 
 
 def intervention_point_context(request, intervention_point_id):
@@ -141,6 +143,7 @@ def intervention_point_context(request, intervention_point_id):
     return context
 
 
+@csrf_exempt
 @lti_role_required(ADMINS)
 def submit_edit_intervention_point(request, intervention_point_id):
     edit_intervention_point_common(request, intervention_point_id)

--- a/ab_tool/views/main_pages.py
+++ b/ab_tool/views/main_pages.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponse
-from django.shortcuts import render_to_response, redirect
-#from django.views.decorators.csrf import csrf_exempt
+from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
 from django_auth_lti.decorators import lti_role_required
 from django.template.defaultfilters import slugify
 from django.template import loader
@@ -20,6 +20,7 @@ def not_authorized(request):
     return HttpResponse(loader.render_to_string("ab_tool/not_authorized.html"), status=401)
 
 
+@csrf_exempt
 @lti_role_required(ADMINS)
 def render_control_panel(request):
     canvas_modules = CanvasModules(request)
@@ -39,7 +40,7 @@ def render_control_panel(request):
         "experiments_with_unassigned_students": experiments_with_unassigned_students(request, course_id),
         "deletable_experiment_ids": canvas_modules.get_deletable_experiment_ids(),
     }
-    return render_to_response("ab_tool/experiments_dashboard.html", context)
+    return render(request, "ab_tool/experiments_dashboard.html", context)
 
 
 def tool_config(request):

--- a/ab_tool/views/selection_pages.py
+++ b/ab_tool/views/selection_pages.py
@@ -1,5 +1,6 @@
-from django.shortcuts import render_to_response, redirect
+from django.shortcuts import redirect, render
 from django.utils.http import urlencode
+from django.views.decorators.csrf import csrf_exempt
 from django_auth_lti.decorators import lti_role_required
 
 from ab_tool.models import (Track, InterventionPointUrl, InterventionPoint,
@@ -12,6 +13,7 @@ from ab_tool.exceptions import (MISSING_RETURN_TYPES_PARAM,
     MISSING_RETURN_URL)
 
 
+@csrf_exempt
 @lti_role_required(ADMINS)
 def resource_selection(request):
     """ docs: https://canvas.instructure.com/doc/api/file.link_selection_tools.html """
@@ -29,7 +31,7 @@ def resource_selection(request):
                "tracks": Track.objects.filter(course_id=course_id),
                "experiments": all_experiments,
                }
-    return render_to_response("ab_tool/add_module_item.html", context)
+    return render(request, "ab_tool/add_module_item.html", context)
 
 
 @lti_role_required(ADMINS)
@@ -48,25 +50,25 @@ def submit_selection(request):
     return redirect("%s?%s" % (content_return_url, urlencode(params)))
 
 
-@lti_role_required(ADMINS)
-def submit_selection_new_intervention_point(request):
-    course_id = get_lti_param(request, "custom_canvas_course_id")
-    name = validate_name(post_param(request, "name"))
-    notes = post_param(request, "notes")
-    experiment_id = post_param(request, "experiment")
-    experiment = Experiment.get_or_404_check_course(experiment_id, course_id)
-    intervention_point = InterventionPoint.objects.create(
-            name=name, notes=notes, course_id=course_id, experiment=experiment)
-    intervention_pointurls = [(k,v) for (k,v) in request.POST.iteritems() if INTERVENTION_POINT_URL_TAG in k and v]
-    for (k,v) in intervention_pointurls:
-        _, track_id = k.split(INTERVENTION_POINT_URL_TAG)
-        InterventionPointUrl.objects.create(url=v, intervention_point_id=intervention_point.id, track_id=track_id)
-    page_url = intervention_point_url(request, intervention_point.id)
-    page_name = intervention_point.name
-    content_return_url = request.REQUEST.get("content_return_url")
-    params = {"return_type": "lti_launch_url",
-               "url": page_url,
-               #"title": "Title",
-               "text": page_name}
-    return redirect("%s?%s" % (content_return_url, urlencode(params)))
-
+# TODO: re-enable submit_selection_new_intervention_point() once it is available through the UI
+# @lti_role_required(ADMINS)
+# def submit_selection_new_intervention_point(request):
+#     course_id = get_lti_param(request, "custom_canvas_course_id")
+#     name = validate_name(post_param(request, "name"))
+#     notes = post_param(request, "notes")
+#     experiment_id = post_param(request, "experiment")
+#     experiment = Experiment.get_or_404_check_course(experiment_id, course_id)
+#     intervention_point = InterventionPoint.objects.create(
+#             name=name, notes=notes, course_id=course_id, experiment=experiment)
+#     intervention_pointurls = [(k,v) for (k,v) in request.POST.iteritems() if INTERVENTION_POINT_URL_TAG in k and v]
+#     for (k,v) in intervention_pointurls:
+#         _, track_id = k.split(INTERVENTION_POINT_URL_TAG)
+#         InterventionPointUrl.objects.create(url=v, intervention_point_id=intervention_point.id, track_id=track_id)
+#     page_url = intervention_point_url(request, intervention_point.id)
+#     page_name = intervention_point.name
+#     content_return_url = request.REQUEST.get("content_return_url")
+#     params = {"return_type": "lti_launch_url",
+#                "url": page_url,
+#                #"title": "Title",
+#                "text": page_name}
+#     return redirect("%s?%s" % (content_return_url, urlencode(params)))


### PR DESCRIPTION
- enables CSRF checks on all forms
- explicitly leaves LTI launch points exempt from CSRF
- marks GET endpoints that have server data consequences for follow-up to prevent CSRF attacks
- removes `submit_selection_new_intervention_point endpoint`, which isn't being used in this version of the app