### PR TITLE
Task/elliottyates/tlt 1159/further csrf protection

### DIFF
--- a/ab_tool/templates/ab_tool/experiments_dashboard.html
+++ b/ab_tool/templates/ab_tool/experiments_dashboard.html
@@ -110,6 +110,7 @@
                             {% for intervention_point in experiment.intervention_points.all %}
                                 <li>
                                     {% if intervention_point in uninstalled_intervention_points and not experiment.tracks_finalized %}
+                                        {# TODO: This can be an AJAX POST with intervention_point.id in the params #}
                                         <form method="post" id="delete_ip_form_{{intervention_point.id}}"
                                               action="{% url 'ab_testing_tool_delete_intervention_point' intervention_point.id %}"
                                               enctype="multipart/form-data">
@@ -167,6 +168,7 @@
                                 </a>
                             </li>
                             <li>
+                                {# TODO: This can be an AJAX POST with intervention_point.id in the params #}
                                 <form method="post" id="copy_experiment_form_{{experiment.id}}"
                                       action="{% url 'ab_testing_tool_copy_experiment' experiment.id %}"
                                       enctype="multipart/form-data">

--- a/ab_tool/templates/ab_tool/experiments_dashboard.html
+++ b/ab_tool/templates/ab_tool/experiments_dashboard.html
@@ -110,12 +110,18 @@
                             {% for intervention_point in experiment.intervention_points.all %}
                                 <li>
                                     {% if intervention_point in uninstalled_intervention_points and not experiment.tracks_finalized %}
-                                        <a href="{% url 'ab_testing_tool_delete_intervention_point' intervention_point.id %}"
-                                            data-toggle="tooltip" data-placement="top"
-                                            title="Delete Intervention Point '{{intervention_point.name}}'"
-                                            class="btn btn-icon-only ip-btn-delete submitter">
-                                            <i class="fa fa-trash"></i><span>Delete</span>
-                                        </a>
+                                        <form method="post" id="delete_ip_form_{{intervention_point.id}}"
+                                              action="{% url 'ab_testing_tool_delete_intervention_point' intervention_point.id %}"
+                                              enctype="multipart/form-data">
+                                            {% csrf_token %}
+                                            <a id="delete_ip_button_{{intervention_point.id}}"
+                                               class="btn btn-icon-only ip-btn-delete submitter"
+                                               onclick="this.parentNode.submit(); return false;"
+                                               data-toggle="tooltip" data-placement="top"
+                                               title="Delete Intervention Point '{{intervention_point.name}}'">
+                                                <i class="fa fa-trash"></i><span>Delete</span>
+                                            </a>
+                                        </form>
                                     {% else %}
                                         <a href="#" class="btn btn-icon-only ip-btn-delete disabled">
                                             <i class="fa fa-trash"></i><span>Delete</span>
@@ -161,9 +167,16 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="{% url 'ab_testing_tool_copy_experiment' experiment.id %}" class="btn btn-icon btn-ip-options" id="copy_experiment_button">
-                                Copy Experiment </a>
-                            
+                                <form method="post" id="copy_experiment_form_{{experiment.id}}"
+                                      action="{% url 'ab_testing_tool_copy_experiment' experiment.id %}"
+                                      enctype="multipart/form-data">
+                                    {% csrf_token %}
+                                    <a id="copy_experiment_button_{{experiment.id}}"
+                                       class="btn btn-icon btn-ip-options"
+                                       onclick="this.parentNode.submit(); return false;">
+                                        Copy Experiment
+                                    </a>
+                                </form>
                             </li>
                             {% if experiment.tracks_finalized %}
                                 <li>

--- a/ab_tool/templates/ab_tool/modals.html
+++ b/ab_tool/templates/ab_tool/modals.html
@@ -334,6 +334,7 @@
                 <p class="text-warning">Are you sure you want to delete experiment "{{experiment.name}}"?  This will also delete all intervention points for this experiment.</p>
             </div>
             <div class="modal-footer">
+                {# TODO: This can be an AJAX POST with intervention_point.id in the params #}
                 <form method="post" id="delete_experiment_form_{{experiment.id}}"
                       action="{% url 'ab_testing_tool_delete_experiment' experiment.id %}"
                       enctype="multipart/form-data">

--- a/ab_tool/templates/ab_tool/modals.html
+++ b/ab_tool/templates/ab_tool/modals.html
@@ -334,8 +334,17 @@
                 <p class="text-warning">Are you sure you want to delete experiment "{{experiment.name}}"?  This will also delete all intervention points for this experiment.</p>
             </div>
             <div class="modal-footer">
-                <a class="btn btn-lg btn-submit-primary" data-dismiss="modal"> Close </a>
-                <a class="btn btn-lg btn-link submitter"  href="{% url 'ab_testing_tool_delete_experiment' experiment.id %}"> Yes, Delete Experiment </a>
+                <form method="post" id="delete_experiment_form_{{experiment.id}}"
+                      action="{% url 'ab_testing_tool_delete_experiment' experiment.id %}"
+                      enctype="multipart/form-data">
+                    {% csrf_token %}
+                    <a class="btn btn-lg btn-submit-primary" data-dismiss="modal"> Close </a>
+                    <a id="delete_experiment_button_{{experiment.id}}"
+                       class="btn btn-lg btn-link submitter"
+                       onclick="this.parentNode.submit(); return false;">
+                        Yes, Delete Experiment
+                    </a>
+                </form>
             </div>
         </div>
     </div>

--- a/ab_tool/tests/test_experiment_pages.py
+++ b/ab_tool/tests/test_experiment_pages.py
@@ -334,8 +334,8 @@ class TestExperimentPages(SessionTestCase):
         first_num_experiments = Experiment.objects.count()
         experiment = self.create_test_experiment()
         self.assertEqual(first_num_experiments + 1, Experiment.objects.count())
-        response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
-                                   follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
+                                    follow=True)
         second_num_experiments = Experiment.objects.count()
         self.assertOkay(response)
         self.assertEqual(first_num_experiments, second_num_experiments)
@@ -345,8 +345,8 @@ class TestExperimentPages(SessionTestCase):
         experiment = self.create_test_experiment()
         experiment.update(tracks_finalized=True)
         first_num_experiments = Experiment.objects.count()
-        response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
-                                   follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
+                                    follow=True)
         second_num_experiments = Experiment.objects.count()
         self.assertError(response, EXPERIMENT_TRACKS_ALREADY_FINALIZED)
         self.assertEqual(first_num_experiments, second_num_experiments)
@@ -360,8 +360,8 @@ class TestExperimentPages(SessionTestCase):
         ret_val = [True]
         with patch("ab_tool.canvas.CanvasModules.experiment_has_installed_intervention",
                    return_value=ret_val):
-            response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
-                                       follow=True)
+            response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
+                                        follow=True)
             second_num_experiments = Experiment.objects.count()
             self.assertError(response, INTERVENTION_POINTS_ARE_INSTALLED)
             self.assertEqual(first_num_experiments, second_num_experiments)
@@ -371,8 +371,8 @@ class TestExperimentPages(SessionTestCase):
         self.set_roles([])
         experiment = self.create_test_experiment()
         first_num_experiments = Experiment.objects.count()
-        response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
-                                   follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
+                                    follow=True)
         second_num_experiments = Experiment.objects.count()
         self.assertTemplateUsed(response, "ab_tool/not_authorized.html")
         self.assertEqual(first_num_experiments, second_num_experiments)
@@ -385,7 +385,7 @@ class TestExperimentPages(SessionTestCase):
         self.create_test_experiment()
         t_id = NONEXISTENT_EXPERIMENT_ID
         first_num_experiments = Experiment.objects.count()
-        response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(t_id,)), follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(t_id,)), follow=True)
         second_num_experiments = Experiment.objects.count()
         self.assertEqual(first_num_experiments, second_num_experiments)
         self.assertOkay(response)
@@ -395,7 +395,7 @@ class TestExperimentPages(SessionTestCase):
             wrong course """
         experiment = self.create_test_experiment(course_id=TEST_OTHER_COURSE_ID)
         first_num_experiments = Experiment.objects.count()
-        response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
+        response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
                                    follow=True)
         second_num_experiments = Experiment.objects.count()
         self.assertEqual(first_num_experiments, second_num_experiments)
@@ -412,8 +412,8 @@ class TestExperimentPages(SessionTestCase):
         InterventionPointUrl.objects.create(intervention_point=intervention_point,
                                             track=track2, url="example.com")
         first_num_intervention_point_urls = InterventionPointUrl.objects.count()
-        response = self.client.get(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
-                                   follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_experiment", args=(experiment.id,)),
+                                    follow=True)
         second_num_intervention_point_urls = InterventionPointUrl.objects.count()
         self.assertOkay(response)
         self.assertEqual(first_num_intervention_point_urls - 2, second_num_intervention_point_urls)
@@ -464,7 +464,7 @@ class TestExperimentPages(SessionTestCase):
         experiment = self.create_test_experiment()
         num_experiments = Experiment.objects.count()
         url = reverse("ab_testing_tool_copy_experiment", args=(experiment.id,))
-        response = self.client.get(url, follow=True)
+        response = self.client.post(url, follow=True)
         self.assertOkay(response)
         self.assertEqual(Experiment.objects.count(), num_experiments + 1)
     
@@ -473,20 +473,20 @@ class TestExperimentPages(SessionTestCase):
         self.set_roles([])
         experiment = self.create_test_experiment()
         url = reverse("ab_testing_tool_copy_experiment", args=(experiment.id,))
-        response = self.client.get(url, follow=True)
+        response = self.client.post(url, follow=True)
         self.assertTemplateUsed(response, "ab_tool/not_authorized.html")
     
     def test_copy_experiment_inavlid_id(self):
         """ Tests that copy_experiment fails with bad experiment_id """
         url = reverse("ab_testing_tool_copy_experiment", args=(12345,))
-        response = self.client.get(url, follow=True)
+        response = self.client.post(url, follow=True)
         self.assertEquals(response.status_code, 404)
     
     def test_copy_experiment_wrong_course(self):
         """ Tests that copy_experiment fails if experiment is different coruse """
         experiment = self.create_test_experiment(course_id=TEST_OTHER_COURSE_ID)
         url = reverse("ab_testing_tool_copy_experiment", args=(experiment.id,))
-        response = self.client.get(url, follow=True)
+        response = self.client.post(url, follow=True)
         self.assertError(response, UNAUTHORIZED_ACCESS)
     
     def test_delete_track(self):

--- a/ab_tool/tests/test_intervention_point_pages.py
+++ b/ab_tool/tests/test_intervention_point_pages.py
@@ -320,8 +320,8 @@ class TestInterventionPointPages(SessionTestCase):
         first_num_intervention_points = InterventionPoint.objects.count()
         intervention_point = self.create_test_intervention_point()
         self.assertEqual(first_num_intervention_points + 1, InterventionPoint.objects.count())
-        response = self.client.get(reverse("ab_testing_tool_delete_intervention_point",
-                                           args=(intervention_point.id,)), follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_intervention_point",
+                                            args=(intervention_point.id,)), follow=True)
         second_num_intervention_points = InterventionPoint.objects.count()
         self.assertOkay(response)
         self.assertEqual(first_num_intervention_points, second_num_intervention_points)
@@ -331,8 +331,8 @@ class TestInterventionPointPages(SessionTestCase):
         self.set_roles([])
         first_num_intervention_points = InterventionPoint.objects.count()
         intervention_point = self.create_test_intervention_point()
-        response = self.client.get(reverse("ab_testing_tool_delete_intervention_point",
-                                           args=(intervention_point.id,)), follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_intervention_point",
+                                            args=(intervention_point.id,)), follow=True)
         second_num_intervention_points = InterventionPoint.objects.count()
         self.assertTemplateUsed(response, "ab_tool/not_authorized.html")
         self.assertNotEqual(first_num_intervention_points, second_num_intervention_points)
@@ -345,8 +345,8 @@ class TestInterventionPointPages(SessionTestCase):
         first_num_intervention_points = InterventionPoint.objects.count()
         self.create_test_intervention_point()
         intervention_point_id = NONEXISTENT_INTERVENTION_POINT_ID
-        response = self.client.get(reverse("ab_testing_tool_delete_intervention_point",
-                                           args=(intervention_point_id,)), follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_intervention_point",
+                                            args=(intervention_point_id,)), follow=True)
         second_num_intervention_points = InterventionPoint.objects.count()
         self.assertOkay(response)
         self.assertNotEqual(first_num_intervention_points, second_num_intervention_points)
@@ -356,8 +356,8 @@ class TestInterventionPointPages(SessionTestCase):
             InterventionPoint but for wrong course """
         first_num_intervention_points = InterventionPoint.objects.count()
         intervention_point = self.create_test_intervention_point(course_id=TEST_OTHER_COURSE_ID)
-        response = self.client.get(reverse("ab_testing_tool_delete_intervention_point",
-                                           args=(intervention_point.id,)), follow=True)
+        response = self.client.post(reverse("ab_testing_tool_delete_intervention_point",
+                                            args=(intervention_point.id,)), follow=True)
         second_num_intervention_points = InterventionPoint.objects.count()
         self.assertError(response, UNAUTHORIZED_ACCESS)
         self.assertNotEqual(first_num_intervention_points, second_num_intervention_points)
@@ -371,8 +371,8 @@ class TestInterventionPointPages(SessionTestCase):
         ret_val = [True]
         with patch("ab_tool.canvas.CanvasModules.intervention_point_is_installed",
                    return_value=ret_val):
-            response = self.client.get(reverse("ab_testing_tool_delete_intervention_point",
-                                               args=(intervention_point.id,)), follow=True)
+            response = self.client.post(reverse("ab_testing_tool_delete_intervention_point",
+                                                args=(intervention_point.id,)), follow=True)
             second_num_intervention_points = InterventionPoint.objects.count()
             self.assertNotEqual(first_num_intervention_points, second_num_intervention_points)
             self.assertError(response, DELETING_INSTALLED_INTERVENTION_POINT)

--- a/ab_tool/views/experiment_pages.py
+++ b/ab_tool/views/experiment_pages.py
@@ -1,5 +1,6 @@
 import json
 from django.shortcuts import render_to_response, redirect, render
+from django.views.decorators.http import require_POST
 from django_auth_lti.decorators import lti_role_required
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -153,7 +154,7 @@ def submit_edit_experiment(request, experiment_id):
     return HttpResponse("success")
 
 
-# TODO: CSRF protection e.g. implement as POST
+@require_POST
 @lti_role_required(ADMINS)
 def copy_experiment(request, experiment_id):
     course_id = get_lti_param(request, "custom_canvas_course_id")
@@ -168,7 +169,7 @@ def copy_experiment(request, experiment_id):
     raise COPIES_EXCEEDS_LIMIT
 
 
-# TODO: CSRF protection e.g. implement as POST
+@require_POST
 @lti_role_required(ADMINS)
 def delete_experiment(request, experiment_id):
     """ If Http404 is raised, delete_experiment redirects regardless. This is by

--- a/ab_tool/views/intervention_point_pages.py
+++ b/ab_tool/views/intervention_point_pages.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render_to_response, redirect, render
 from django.core.urlresolvers import reverse
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django_auth_lti.decorators import lti_role_required
 
 from ab_tool.constants import (ADMINS, INTERVENTION_POINT_URL_TAG,
@@ -186,7 +187,7 @@ def edit_intervention_point_common(request, intervention_point_id):
                                     is_canvas_page=is_canvas_page, open_as_tab=open_as_tab)
 
 
-# TODO: CSRF protection e.g. implement as POST
+@require_POST
 @lti_role_required(ADMINS)
 def delete_intervention_point(request, intervention_point_id):
     """ Note: Installed intervention_points are not allowed to be deleted


### PR DESCRIPTION
- adds CSRF protection to remaining non-angular side-effect-inducing endpoints: copy experiment, delete experiment, delete IP
- updates unit tests
- incorporates TODO comments from original PR https://github.com/penzance/ab-testing-tool/pull/178/files