### PR TITLE
Feature/aws settings reorg

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "hashicorp/precise64"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -42,21 +38,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider :virtualbox do |vb|
-  #   # Don't boot with headless mode
-  #   vb.gui = true
-  #
-  #   # Use VBoxManage to customize the VM. For example to change memory:
-  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
-  # end
-  #
-  # View the documentation for the provider you're using for more
-  # information on available options.
 
   # Add stdlib so we can use file_line module
   config.vm.provision :shell do |shell|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |v|
+    # Seems to be required for Ubuntu
+    # https://www.virtualbox.org/manual/ch03.html#settings-processor
+    v.customize ["modifyvm", :id, "--pae", "on"]
+    # Recommended for Ubuntu
+    v.cpus = 2
+    # This VM comes without swap memory enabled, so we need to bump up
+    # from 512 in order to accomodate installation of lxml
+    v.memory = 768
+  end
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,28 +58,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-  # Enable provisioning with Puppet stand alone.  Puppet manifests
-  # are contained in a directory path relative to this Vagrantfile.
-  # You will need to create the manifests directory and a manifest in
-  # the file precise64.pp in the manifests_path directory.
-  #
-  # An example Puppet manifest to provision the message of the day:
-  #
-  # # group { "puppet":
-  # #   ensure => "present",
-  # # }
-  # #
-  # # File { owner => 0, group => 0, mode => 0644 }
-  # #
-  # # file { '/etc/motd':
-  # #   content => "Welcome to your Vagrant-built virtual machine!
-  # #               Managed by Puppet.\n"
-  # # }
-  #
-  # config.vm.provision :puppet do |puppet|
-  #   puppet.manifests_path = "manifests"
-  #   puppet.manifest_file  = "site.pp"
-  # end
+  # Add stdlib so we can use file_line module
+  config.vm.provision :shell do |shell|
+    shell.inline = "mkdir -p /etc/puppet/modules;
+                    puppet module install puppetlabs-stdlib --force;"
+  end
 
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "vagrant/manifests"

--- a/ab_testing_tool/requirements/aws.txt
+++ b/ab_testing_tool/requirements/aws.txt
@@ -1,0 +1,2 @@
+# Requirements for environments deployed to aws
+-r base.txt

--- a/ab_testing_tool/requirements/base.txt
+++ b/ab_testing_tool/requirements/base.txt
@@ -1,11 +1,12 @@
+pip==7.1.0
 Django==1.8.3
-rauth
+rauth==0.7.1
 django-cached-authentication-middleware==0.2.1
-git+https://github.com/Harvard-University-iCommons/django-auth-lti.git@v0.9#egg=django-auth-lti
-git+https://github.com/penzance/canvas_python_sdk.git@v0.7b5#egg=canvas-python-sdk>=0.7
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.0#egg=django-auth-lti==1.0
+git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7.8#egg=canvas-python-sdk==0.7.8
 redis==2.10.3
 django-redis-cache==1.5.3
 hiredis==0.2.0
-xlsxwriter
-xlrd
+xlsxwriter==0.7.3
+xlrd==0.9.4
 psycopg2==2.6.1

--- a/ab_testing_tool/requirements/base.txt
+++ b/ab_testing_tool/requirements/base.txt
@@ -1,16 +1,11 @@
-Django>=1.7,<1.8
-ims_lti_py
-dj-static>=0.0.6
+Django==1.8.3
 rauth
-mock
-jasmine
+django-cached-authentication-middleware==0.2.1
 git+https://github.com/Harvard-University-iCommons/django-auth-lti.git@v0.9#egg=django-auth-lti
 git+https://github.com/penzance/canvas_python_sdk.git@v0.7b5#egg=canvas-python-sdk>=0.7
-# redis cache
-redis==2.9.0
-django-redis-cache==0.10.2
-hiredis==0.1.2
-gunicorn
+redis==2.10.3
+django-redis-cache==1.5.3
+hiredis==0.2.0
 xlsxwriter
 xlrd
-psycopg2
+psycopg2==2.6.1

--- a/ab_testing_tool/requirements/demo.txt
+++ b/ab_testing_tool/requirements/demo.txt
@@ -1,4 +1,2 @@
 # demo environment requirements
-
-#includes the base.txt requirements needed in all environments
--r base.txt 
+-r aws.txt 

--- a/ab_testing_tool/requirements/local.txt
+++ b/ab_testing_tool/requirements/local.txt
@@ -7,3 +7,5 @@
 django-debug-toolbar
 django-sslserver==0.14
 pep8
+mock
+jasmine

--- a/ab_testing_tool/requirements/production.txt
+++ b/ab_testing_tool/requirements/production.txt
@@ -1,6 +1,2 @@
 # production environment requirements
-
-#includes the base.txt requirements needed in all environments
--r base.txt 
- 
-# below are requirements specific to the production environment
+-r aws.txt

--- a/ab_testing_tool/requirements/qa.txt
+++ b/ab_testing_tool/requirements/qa.txt
@@ -1,6 +1,2 @@
 # qa environment requirements
-
-#includes the base.txt requirements needed in all environments
--r base.txt 
- 
-# below are requirements specific to the qa environment
+-r aws.txt

--- a/ab_testing_tool/requirements/test.txt
+++ b/ab_testing_tool/requirements/test.txt
@@ -1,6 +1,2 @@
 # test environment requirements
-
-#includes the base.txt requirements needed in all environments
--r base.txt
- 
-# below are requirements specific to the test environment
+-r aws.txt

--- a/ab_testing_tool/settings/aws.py
+++ b/ab_testing_tool/settings/aws.py
@@ -1,0 +1,19 @@
+from .base import *
+
+# tlt hostnames
+ALLOWED_HOSTS = ['.tlt.harvard.edu']
+
+# AWS Email Settings
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'email-smtp.us-east-1.amazonaws.com'
+EMAIL_USE_TLS = True
+# Amazon Elastic Compute Cloud (Amazon EC2) throttles email traffic over port 25 by default.
+# To avoid timeouts when sending email through the SMTP endpoint from EC2, use a different
+# port (587 or 2587)
+EMAIL_PORT = 587
+EMAIL_HOST_USER = SECURE_SETTINGS.get('email_host_user', '')
+EMAIL_HOST_PASSWORD = SECURE_SETTINGS.get('email_host_password', '')
+
+# SSL is terminated at the ELB so look for this header to know that we should be in ssl mode
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SECURE = True

--- a/ab_testing_tool/settings/base.py
+++ b/ab_testing_tool/settings/base.py
@@ -5,18 +5,15 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.8/topics/settings
 """
 import os
-from .secure import SECURE_SETTINGS as ENV
+from .secure import SECURE_SETTINGS
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ENV.get('django_secret_key', 'changeme')
+SECRET_KEY = SECURE_SETTINGS.get('django_secret_key', 'changeme')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = ENV.get('enable_debug', False)
-
-# Current environment
-ENV_NAME = ENV.get('env_name', 'local')
+DEBUG = SECURE_SETTINGS.get('enable_debug', False)
 
 # Application definition
 
@@ -57,7 +54,7 @@ ROOT_URLCONF = 'ab_testing_tool.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.normpath(os.path.join(BASE_DIR, 'templates'))],
+        'DIRS': [os.path.normpath(os.path.join(BASE_DIR, 'ab_testing_tool', 'templates'))],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -79,20 +76,51 @@ WSGI_APPLICATION = 'ab_testing_tool.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': ENV.get('db_default_name', 'lti_emailer'),
-        'USER': ENV.get('db_default_user', 'postgres'),
-        'PASSWORD': ENV.get('db_default_password'),
-        'HOST': ENV.get('db_default_host', '127.0.0.1'),
-        'PORT': ENV.get('db_default_port', 5432),  # Default postgres port
+        'NAME': SECURE_SETTINGS.get('db_default_name', 'lti_emailer'),
+        'USER': SECURE_SETTINGS.get('db_default_user', 'postgres'),
+        'PASSWORD': SECURE_SETTINGS.get('db_default_password'),
+        'HOST': SECURE_SETTINGS.get('db_default_host', '127.0.0.1'),
+        'PORT': SECURE_SETTINGS.get('db_default_port', 5432),  # Default postgres port
     }
 }
 
+# Cache
+# https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-CACHES
+
+REDIS_HOST = SECURE_SETTINGS.get('redis_host', '127.0.0.1')
+REDIS_PORT = SECURE_SETTINGS.get('redis_port', 6379)
+
+CACHES = {
+    'default': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': "redis://%s:%s/0" % (REDIS_HOST, REDIS_PORT),
+        'OPTIONS': {
+            'PARSER_CLASS': 'redis.connection.HiredisParser'
+        },
+        'KEY_PREFIX': 'ab_testing_tool',  # Provide a unique value for shared cache
+        # See following for default timeout (5 minutes as of 1.7):
+        # https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-CACHES-TIMEOUT
+        'TIMEOUT': SECURE_SETTINGS.get('default_cache_timeout_secs', 300),
+    },
+}
+
+# Sessions
+
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
+SESSION_COOKIE_NAME = 'djsessionid'
+
+# NOTE: This setting only affects the session cookie, not the expiration of the session
+# being stored in the cache.  The session keys will expire according to the value of
+# SESSION_COOKIE_AGE, which defaults to 2 weeks when no value is given.
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
 # Internationalization
-# https://docs.djangoproject.com/en/1.6/topics/i18n/
+# https://docs.djangoproject.com/en/1.8/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
@@ -100,101 +128,28 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.6/howto/static-files/
+# https://docs.djangoproject.com/en/1.8/howto/static-files/
 
-STATIC_URL = '/ab-testing/static/'
+STATIC_URL = '/static/'
 
-STATIC_ROOT = normpath(join(SITE_ROOT, 'http_static'))
+STATIC_ROOT = os.path.normpath(os.path.join(BASE_DIR, 'http_static'))
 
-# renderable_error.html is the default template specified in error_middleware and can be changed if desired
-RENDERABLE_ERROR_TEMPLATE = "renderable_error.html"
-# oauth_error.html is the default template specified in django_canvas_oauth and can be changed if desired
-OAUTH_ERROR_TEMPLATE = "oauth_error.html"
+# Logging
 
-CANVAS_OAUTH_CLIENT_ID = ENV_SETTINGS.get('client_id')
-CANVAS_OAUTH_CLIENT_SECRET = ENV_SETTINGS.get('client_secret')
-
-LTI_OAUTH_CREDENTIALS = ENV_SETTINGS.get('lti_oauth_credentials', None)
-
-# This is for https forwarding on server
-# SECURITY WARNING: https://docs.djangoproject.com/en/1.7/ref/settings/#secure-proxy-ssl-header
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
-if ENV_SETTINGS.get('redis_cache_host'):
-     REDIS_HOST = ENV_SETTINGS.get('redis_host', '127.0.0.1')
-     REDIS_PORT = ENV_SETTINGS.get('redis_port', 6379)
-     CACHES = {
-         'default': {
-             'BACKEND': 'redis_cache.RedisCache',
-             'LOCATION': "%s:%s" % (REDIS_HOST, REDIS_PORT),
-             'OPTIONS': {
-                 'PARSER_CLASS': 'redis.connection.HiredisParser'
-             },
-             'KEY_PREFIX': 'ab_testing_tool',  # Provide a unique value for shared cache
-             'TIMEOUT': 60 * 20,  # 20 minutes
-         },
-     }
-
-    # CACHES = {
-    #     'default': {
-    #         'BACKEND': 'redis_cache.RedisCache',
-    #         'LOCATION': ENV_SETTINGS.get('redis_cache_host'),
-    #         'OPTIONS': {
-    #             'PARSER_CLASS': 'redis.connection.HiredisParser'
-    #         },
-    #     },
-    # }
-
-if ENV_SETTINGS.get('redis_sessions_host'):
-    SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-    #SESSION_ENGINE = 'redis_sessions.session'
-    #SESSION_REDIS_HOST = ENV_SETTINGS.get('redis_sessions_host', 'localhost')
-    #SESSION_REDIS_PORT = ENV_SETTINGS.get('redis_sessions_port', 6379)
-
-# Django defaults to False (as of 1.7)
-SESSION_COOKIE_SECURE = ENV_SETTINGS.get('use_secure_cookies', False)
-
-# session cookie lasts for 7 hours (in seconds)
-SESSION_COOKIE_AGE = 60 * 60 * 7
-
-SESSION_COOKIE_NAME = 'djsessionid'
-
-SESSION_COOKIE_HTTPONLY = True
-
-COURSE_ACTIVE_DAYS = 365
-NOTIFICATION_FREQUENCY_HOURS = 24
-
-MAX_FILE_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
-
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = ENV_SETTINGS.get('email_host', 'localhost')
-EMAIL_HOST_USER = ENV_SETTINGS.get('email_host_user', '')
-EMAIL_HOST_PASSWORD = ENV_SETTINGS.get('email_host_password', '')
-EMAIL_USE_TLS = ENV_SETTINGS.get('email_use_tls', False)
-EMAIL_PORT = ENV_SETTINGS.get('email_port', 25)
-# Email address that error messages come from
-# See Django doc for current default value at:
-# https://docs.djangoproject.com/en/[version]/ref/settings/#std:setting-SERVER_EMAIL
-SERVER_EMAIL = ENV_SETTINGS.get('email_server_email', 'root@localhost')
-# Email address used in send_mail if no from address is specified, see
-# See Django doc for current default value at:
-# https://docs.djangoproject.com/en/[version]/ref/settings/#std:setting-DEFAULT_FROM_EMAIL
-DEFAULT_FROM_EMAIL = ENV_SETTINGS.get('email_default_from_email', 'webmaster@localhost')
-
-_DEFAULT_LOG_LEVEL = ENV_SETTINGS.get('log_level', 'DEBUG')
-_LOG_ROOT = ENV_SETTINGS.get('log_root', '')
+_DEFAULT_LOG_LEVEL = SECURE_SETTINGS.get('log_level', 'DEBUG')
+_LOG_ROOT = SECURE_SETTINGS.get('log_root', '')
 
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,  # Merge this with Django's default logging configuration
     'formatters': {
         'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+            'format': '%(levelname)s\t%(asctime)s.%(msecs)03dZ\t%(name)s:%(lineno)s\t%(message)s',
+            'datefmt': '%Y-%m-%dT%H:%M:%S'
         },
         'simple': {
-            'format': '%(levelname)s %(module)s %(message)s'
+            'format': '%(levelname)s\t%(name)s:%(lineno)s\t%(message)s',
         }
     },
     # Borrowing some default filters for app loggers
@@ -208,16 +163,10 @@ LOGGING = {
     },
     'handlers': {
         'console': {
-            'level': _DEFAULT_LOG_LEVEL,
+            'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'simple',
             'filters': ['require_debug_true'],
-        },
-        # In case we turn on mail for any of the below loggers
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler',
-            'filters': ['require_debug_false'],
         },
         # For testing purposes and fallback for mail filter
         'null': {
@@ -226,28 +175,25 @@ LOGGING = {
         'logfile': {
             'level': _DEFAULT_LOG_LEVEL,
             'class': 'logging.handlers.WatchedFileHandler',
-            'filename': normpath(join(_LOG_ROOT, 'django-ab_testing_tool.log')),
+            'filename': os.path.normpath(os.path.join(_LOG_ROOT, 'django-ab_testing_tool.log')),
             'formatter': 'verbose',
         },
         'jobs-logfile': {
             'level': _DEFAULT_LOG_LEVEL,
             'class': 'logging.handlers.WatchedFileHandler',
-            'filename': normpath(join(_LOG_ROOT, 'django-jobs-ab_testing_tool.log')),
+            'filename': os.path.normpath(os.path.join(_LOG_ROOT, 'django-jobs-ab_testing_tool.log')),
             'formatter': 'verbose'
         },
     },
     'loggers': {
         'django_auth_lti': {
             'handlers': ['console', 'logfile'],
-            'level': 'DEBUG',
         },
         'ab_tool': {
-            'handlers': ['console', 'logfile', 'mail_admins'],
-            'level': 'DEBUG',
+            'handlers': ['console', 'logfile'],
         },
         'ab_tool.management': {
-            'handlers': ['console', 'jobs-logfile', 'mail_admins'],
-            'level': 'DEBUG',
+            'handlers': ['console', 'jobs-logfile'],
             'propagate': False,
         },
         'django.request': {
@@ -257,7 +203,35 @@ LOGGING = {
         },
         'error_middleware': {
             'handlers': ['console', 'logfile'],
-            'level': 'DEBUG',
         }
     },
 }
+
+# Currently deployed environment
+ENV_NAME = SECURE_SETTINGS.get('env_name', 'local')
+
+# Other app specific settings
+
+# renderable_error.html is the default template specified in error_middleware and can be changed if desired
+RENDERABLE_ERROR_TEMPLATE = "renderable_error.html"
+# oauth_error.html is the default template specified in django_canvas_oauth and can be changed if desired
+OAUTH_ERROR_TEMPLATE = "oauth_error.html"
+
+CANVAS_OAUTH_CLIENT_ID = SECURE_SETTINGS.get('client_id')
+CANVAS_OAUTH_CLIENT_SECRET = SECURE_SETTINGS.get('client_secret')
+
+LTI_OAUTH_CREDENTIALS = SECURE_SETTINGS.get('lti_oauth_credentials', None)
+
+COURSE_ACTIVE_DAYS = 365
+NOTIFICATION_FREQUENCY_HOURS = 24
+
+MAX_FILE_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
+
+# Email address that error messages come from
+# See Django doc for current default value at:
+# https://docs.djangoproject.com/en/[version]/ref/settings/#std:setting-SERVER_EMAIL
+SERVER_EMAIL = SECURE_SETTINGS.get('email_server_email', 'root@localhost')
+# Email address used in send_mail if no from address is specified, see
+# See Django doc for current default value at:
+# https://docs.djangoproject.com/en/[version]/ref/settings/#std:setting-DEFAULT_FROM_EMAIL
+DEFAULT_FROM_EMAIL = SECURE_SETTINGS.get('email_default_from_email', 'webmaster@localhost')

--- a/ab_testing_tool/settings/base.py
+++ b/ab_testing_tool/settings/base.py
@@ -76,7 +76,7 @@ WSGI_APPLICATION = 'ab_testing_tool.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': SECURE_SETTINGS.get('db_default_name', 'lti_emailer'),
+        'NAME': SECURE_SETTINGS.get('db_default_name', 'ab_testing_tool'),
         'USER': SECURE_SETTINGS.get('db_default_user', 'postgres'),
         'PASSWORD': SECURE_SETTINGS.get('db_default_password'),
         'HOST': SECURE_SETTINGS.get('db_default_host', '127.0.0.1'),

--- a/ab_testing_tool/settings/demo.py
+++ b/ab_testing_tool/settings/demo.py
@@ -1,1 +1,1 @@
-from .base import *
+from .aws import *

--- a/ab_testing_tool/settings/local.py
+++ b/ab_testing_tool/settings/local.py
@@ -1,3 +1,18 @@
 from .base import *
 
+ALLOWED_HOSTS = ['*']
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# For local development, allow setting a token in ENV_SETTINGS
+COURSE_OAUTH_TOKEN = SECURE_SETTINGS.get("course_oauth_token")
+
 INSTALLED_APPS += ('debug_toolbar', 'sslserver')
+
+MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+
+# For Django Debug Toolbar:
+INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
+DEBUG_TOOLBAR_CONFIG = {
+    'INTERCEPT_REDIRECTS': False,
+}

--- a/ab_testing_tool/settings/production.py
+++ b/ab_testing_tool/settings/production.py
@@ -1,1 +1,1 @@
-from .base import *
+from .aws import *

--- a/ab_testing_tool/settings/qa.py
+++ b/ab_testing_tool/settings/qa.py
@@ -1,1 +1,1 @@
-from .base import *
+from .aws import *

--- a/ab_testing_tool/settings/test.py
+++ b/ab_testing_tool/settings/test.py
@@ -1,1 +1,1 @@
-from .base import *
+from .aws import *

--- a/ab_testing_tool/settings/test_settings.py
+++ b/ab_testing_tool/settings/test_settings.py
@@ -1,10 +1,10 @@
-from .base import *
+from .local import *
 
 # NOTE: when running tests DEBUG mode is enabled regardless of setting it explicitly to False
 
 # To disable logging during test runs, we add a null handler and
 # set each logger's handler to it.
-if not ENV_SETTINGS.get('enable_test_logging'):
+if not SECURE_SETTINGS.get('enable_test_logging'):
     for logger in LOGGING['loggers']:
         LOGGING['loggers'][logger]['handlers'] = ['null']
 
@@ -12,8 +12,12 @@ if not ENV_SETTINGS.get('enable_test_logging'):
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'TEST': {
-            'NAME': os.path.join(BASE_DIR, 'test.sqlite3'),
-        }
+        'NAME': 'ab_testing_tool',
+    },
+}
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
     },
 }

--- a/ab_testing_tool/urls.py
+++ b/ab_testing_tool/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
-
 from ab_tool.views.main_pages import not_authorized
 
 admin.autodiscover()
@@ -8,7 +7,7 @@ admin.autodiscover()
 urlpatterns = patterns(
     '',
     url(r'^not_authorized$', not_authorized, name='not_authorized'),
-    url(r'^lti/', include("ab_tool.urls", app_name="ab_tool")),
-    url(r'^oauth/', include("django_canvas_oauth.urls", namespace="django_canvas_oauth")),
+    url(r'^lti/', include('ab_tool.urls')),
+    url(r'^oauth/', include('django_canvas_oauth.urls', namespace='django_canvas_oauth')),
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/ab_testing_tool/urls.py
+++ b/ab_testing_tool/urls.py
@@ -7,8 +7,8 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^ab-testing/not_authorized$', not_authorized, name='not_authorized'),
-    url(r'^ab-testing/lti/', include("ab_tool.urls", app_name="ab_tool")),
-    url(r'^ab-testing/oauth/', include("django_canvas_oauth.urls", namespace="django_canvas_oauth")),
-    url(r'^ab-testing/admin/', include(admin.site.urls)),
+    url(r'^not_authorized$', not_authorized, name='not_authorized'),
+    url(r'^lti/', include("ab_tool.urls", app_name="ab_tool")),
+    url(r'^oauth/', include("django_canvas_oauth.urls", namespace="django_canvas_oauth")),
+    url(r'^admin/', include(admin.site.urls)),
 )

--- a/ab_testing_tool/wsgi.py
+++ b/ab_testing_tool/wsgi.py
@@ -8,9 +8,7 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
 
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ab_testing_tool.settings")
-
 from django.core.wsgi import get_wsgi_application
-#application = get_wsgi_application()
-from dj_static import Cling
-application = Cling(get_wsgi_application())
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ab_testing_tool.settings.aws")
+application = get_wsgi_application()

--- a/ab_tool/canvas.py
+++ b/ab_tool/canvas.py
@@ -171,9 +171,8 @@ def get_lti_param(request, key):
 
 def get_canvas_request_context(request):
     """ This method creates the needed RequestContext for communication with the Canvas API """
-    if "course_oauth_token" in settings.ENV_SETTINGS and settings.DEBUG:
-        # For local development, allow setting a token in ENV_SETTINGS
-        oauth_token = settings.ENV_SETTINGS["course_oauth_token"]
+    if getattr(settings, 'COURSE_OAUTH_TOKEN', None):
+        oauth_token = settings.COURSE_OAUTH_TOKEN
     else:
         oauth_token = get_token(request)
     canvas_domain = get_lti_param(request, "custom_canvas_api_domain")

--- a/ab_tool/tests/test_controllers.py
+++ b/ab_tool/tests/test_controllers.py
@@ -93,8 +93,9 @@ class TestControllers(SessionTestCase):
         """ Tests that validate_format_url adds http:// to a url missing it """
         url = "com"
         self.assertRaisesSpecific(INVALID_URL_PARAM, validate_format_url, url)
-        url = "http://" + "a"*2046 + ".com"
-        self.assertRaisesSpecific(INVALID_URL_PARAM, validate_format_url, url)
+        # Below test url is valid in Django 1.8+
+        # url = "http://" + "a"*2046 + ".com"
+        # self.assertRaisesSpecific(INVALID_URL_PARAM, validate_format_url, url)
     
     def test_post_param_success(self):
         """ Test that post_param returns correct value when param is present """

--- a/manage.py
+++ b/manage.py
@@ -3,9 +3,8 @@ import os
 import sys
 
 if __name__ == "__main__":
-    settings_module = "test_settings" if "test" in sys.argv else "local"
+    settings_module = "test_settings" if "test" in sys.argv else "aws"
     settings_path = "ab_testing_tool.settings." + settings_module
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_path)
-    
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/manage.py
+++ b/manage.py
@@ -3,8 +3,11 @@ import os
 import sys
 
 if __name__ == "__main__":
-    settings_module = "test_settings" if "test" in sys.argv else "aws"
-    settings_path = "ab_testing_tool.settings." + settings_module
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_path)
+    if 'test' in sys.argv:
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'ab_testing_tool.settings.test_settings'
+    else:
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ab_testing_tool.settings.aws')
+
     from django.core.management import execute_from_command_line
+
     execute_from_command_line(sys.argv)

--- a/supervisor.conf.j2
+++ b/supervisor.conf.j2
@@ -1,8 +1,0 @@
-[program:gunicorn-{{ project_name }}]
-command=/var/opt/virtualenvs/{{ project_name }}/bin/gunicorn -c /opt/tlt/{{ project_name }}/gunicorn.py {{ project_name }}.wsgi:application
-user=deploy
-directory=/opt/tlt/{{ project_name }}
-environment=DJANGO_SETTINGS_MODULE="{{ project_name }}.settings.{{ django_settings | default(deploy_env) }}",ORACLE_HOME="/opt/oracle/instantclient_11_2",LD_LIBRARY_PATH="/opt/oracle/instantclient_11_2"
-
-[group:{{ project_name }}]
-programs=gunicorn-{{ project_name }}

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -20,6 +20,11 @@ exec {'apt-get-update':
 
 # make sure we have some basic tools and libraries available
 
+package {'redis-server':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
 package {'libxslt1-dev':
     ensure => latest,
     require => Exec['apt-get-update'],
@@ -46,11 +51,6 @@ package {'libaio1':
 }
 
 package {'libaio-dev':
-    ensure => installed,
-    require => Exec['apt-get-update']
-}
-
-package {'libpq-dev':
     ensure => installed,
     require => Exec['apt-get-update']
 }
@@ -100,7 +100,57 @@ package {'sqlite3':
     require => Exec['apt-get-update'],
 }
 
-# Install virtualenv and virtualenvwrapper - depends on pip
+# Install Postgresql
+package {'postgresql':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
+package {'postgresql-contrib':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
+package {'libpq-dev':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
+# Create vagrant user for postgresql
+exec {'create-postgresql-user':
+    require => Package['postgresql'],
+    command => 'sudo -u postgres createuser --superuser vagrant'
+}
+
+# Create vagrant db for postgresql
+exec {'create-postgresql-db':
+    require => Exec['create-postgresql-user'],
+    command => 'sudo -u postgres createdb vagrant'
+}
+
+# Ensure github.com ssh public key is in the .ssh/known_hosts file so
+# pip won't try to prompt on the terminal to accept it
+file {'/home/vagrant/.ssh':
+    ensure => directory,
+    mode => 0700,
+}
+
+exec {'known_hosts':
+    provider => 'shell',
+    user => 'vagrant',
+    group => 'vagrant',
+    command => 'ssh-keyscan github.com >> /home/vagrant/.ssh/known_hosts',
+    unless => 'grep -sq github.com /home/vagrant/.ssh/known_hosts',
+    require => [ File['/home/vagrant/.ssh'], ],
+}
+
+file {'/home/vagrant/.ssh/known_hosts':
+    ensure => file,
+    mode => 0744,
+    require => [ Exec['known_hosts'], ],
+}
+
+# install virtualenv and virtualenvwrapper - depends on pip
 
 package {'virtualenv':
     ensure => latest,
@@ -114,7 +164,6 @@ package {'virtualenvwrapper':
     require => [ Package['python-pip'], ],
 }
 
-# make sure that virtualenvwrapper is active
 file {'/etc/profile.d/venvwrapper.sh':
     ensure => file,
     content => 'source `which virtualenvwrapper.sh`',
@@ -122,10 +171,45 @@ file {'/etc/profile.d/venvwrapper.sh':
     require => Package['virtualenvwrapper'],
 }
 
-# Create a symlink from ~/ab_testing_tool to /vagrant as a convenience for the developer
-file {'/home/vagrant/ab_testing_tool':
-    ensure => link,
-    target => '/vagrant',
+# Create a virtualenv for <project_name>
+exec {'create-virtualenv':
+    provider => 'shell',
+    user => 'vagrant',
+    group => 'vagrant',
+    require => [ Package['virtualenvwrapper'], File['/home/vagrant/ab_testing_tool'],
+                 Exec['known_hosts'], ],
+    environment => ["HOME=/home/vagrant","WORKON_HOME=/home/vagrant/.virtualenvs"],
+    command => '/vagrant/vagrant/venv_bootstrap.sh',
+    creates => '/home/vagrant/.virtualenvs/ab_testing_tool',
 }
 
+# set the DJANGO_SETTINGS_MODULE environment variable
+file_line {'add DJANGO_SETTINGS_MODULE env to postactivate':
+    ensure => present,
+    line => 'export DJANGO_SETTINGS_MODULE=ab_testing_tool.settings.local',
+    path => '/home/vagrant/.virtualenvs/ab_testing_tool/bin/postactivate',
+    require => Exec['create-virtualenv'],
+}
 
+file_line {'add DJANGO_SETTINGS_MODULE env to postdeactivate':
+    ensure => present,
+    line => 'unset DJANGO_SETTINGS_MODULE',
+    path => '/home/vagrant/.virtualenvs/ab_testing_tool/bin/postdeactivate',
+    require => Exec['create-virtualenv'],
+}
+
+# Active this virtualenv upon login
+file {'/home/vagrant/.bash_profile':
+    owner => 'vagrant',
+    content => '
+echo "Activating python virtual environment \"ab_testing_tool\""
+workon ab_testing_tool
+        
+# Show git repo branch at bash prompt
+parse_git_branch() {
+    git branch 2> /dev/null | sed -e \'/^[^*]/d\' -e \'s/* \(.*\)/(\1)/\'
+}
+PS1="${debian_chroot:+($debian_chroot)}\u@\h:\w\$(parse_git_branch) $ "
+    ',
+    require => Exec['create-virtualenv'],
+}

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -30,6 +30,16 @@ package {'libxslt1-dev':
     require => Exec['apt-get-update'],
 }
 
+package {'libxml2':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
+package {'libxml2-dev':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
 package {'build-essential':
     ensure => latest,
     require => Exec['apt-get-update'],
@@ -45,14 +55,9 @@ package {'python-pip':
     require => Package['python-dev']
 }
 
-package {'libaio1':
+package {'python-setuptools':
     ensure => installed,
-    require => Exec['apt-get-update']
-}
-
-package {'libaio-dev':
-    ensure => installed,
-    require => Exec['apt-get-update']
+    require => Package['python-dev']
 }
 
 package {'git':
@@ -169,6 +174,12 @@ file {'/etc/profile.d/venvwrapper.sh':
     content => 'source `which virtualenvwrapper.sh`',
     mode => '755',
     require => Package['virtualenvwrapper'],
+}
+
+# Create a symlink from ~/ab_testing_tool to /vagrant as a convenience for the developer
+file {'/home/vagrant/ab_testing_tool':
+    ensure => link,
+    target => '/vagrant',
 }
 
 # Create a virtualenv for <project_name>

--- a/vagrant/venv_bootstrap.sh
+++ b/vagrant/venv_bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export HOME=/home/vagrant
+export WORKON_HOME=$HOME/.virtualenvs
+source /usr/local/bin/virtualenvwrapper.sh
+mkvirtualenv -a /home/vagrant/ab_testing_tool -r /home/vagrant/ab_testing_tool/ab_testing_tool/requirements/local.txt ab_testing_tool 


### PR DESCRIPTION
Many updates include:
* Use of aws settings and requirements files and inclusion of it by other settings/requirements files
* Requirements upgrades and pinning
* Settings improvements and standardizations for CACHE and DATABASE
* Django 1.8 and test fixes for 1.8
* Logging simplifications
* UTC time
* Removal of ab-testing url prefix
* Deprecate dj_static so nginx can serve static assets instead
* Provisioning now sets DJANGO_SETTINGS_MODULE to use local settings
* Fixed scenario where settings module env setting was being respected even when running tests
* Upgrade VM box to Ubuntu 14 and update some of the provisioning

@douglashall 
@rascalking 
@hktest 