### PR TITLE
There is no `app_logfile` handler.  Unit tests are passing, but this …

### DIFF
--- a/ab_testing_tool/settings/base.py
+++ b/ab_testing_tool/settings/base.py
@@ -287,7 +287,7 @@ LOGGING = {
             'propagate': False,
         },
         'django.request': {
-            'handlers': ['console', 'app_logfile'],
+            'handlers': ['console', 'logfile'],
             'level': 'ERROR',
             'propagate': False,
         },


### PR DESCRIPTION
…is causing deployments to fail, so fixing for dev.

@hktest 
@ekiczek 